### PR TITLE
Correct the compilation broken by PR 39.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ makefile.local:
 
 include makefile.local
 
-SRCS = dataStructures.f90 atchem.f90 mechanism-rates.f90 configFunctions.f90 utilityFunctions.f90 solverFunctions.f90 inputFunctions.f90 outputFunctions.f90 interpolationFunctions.f90 constraintFunctions.f90 instantaneousRatesFunctions.f90 facsimileFunctions.f90 conversionFunctions.f90
+SRCS = dataStructures.f90 atchem.f90 mechanism-rates.f90 configFunctions.f90 solverFunctions.f90 inputFunctions.f90 outputFunctions.f90 interpolationFunctions.f90 constraintFunctions.f90 instantaneousRatesFunctions.f90 facsimileFunctions.f90 conversionFunctions.f90
 
 LDFLAGS = -L$(CVODELIB) -Wl,-rpath,$(CVODELIB) -lsundials_fcvode -lsundials_cvode -lsundials_fnvecserial -lsundials_nvecserial -lblas -llapack
 
@@ -81,4 +81,3 @@ mechanism-rates.o : mechanism-rates.f90 modelConfiguration/mechanism-rate-coeffi
 configFunctions.o : configFunctions.f90
 outputFunctions.o : outputFunctions.f90 dataStructures.o
 solverFunctions.o : solverFunctions.f90 dataStructures.o dataStructures.o dataStructures.o dataStructures.o dataStructures.o
-utilityFunctions.o : utilityFunctions.f90 dataStructures.o dataStructures.o

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ makefile.local:
 
 include makefile.local
 
-SRCS = dataStructures.f90 atchem.f90 mechanism-rates.f90 configFunctions.f90 solverFunctions.f90 inputFunctions.f90 outputFunctions.f90 interpolationFunctions.f90 constraintFunctions.f90 instantaneousRatesFunctions.f90 facsimileFunctions.f90 conversionFunctions.f90
+SRCS = dataStructures.f90 atchem.f90 mechanism-rates.f90 configFunctions.f90 solverFunctions.f90 inputFunctions.f90 outputFunctions.f90 interpolationFunctions.f90 constraintFunctions.f90 instantaneousRatesFunctions.f90 facsimileFunctions.f90 conversionFunctions.f90 utilityFunctions.f90
 
 LDFLAGS = -L$(CVODELIB) -Wl,-rpath,$(CVODELIB) -lsundials_fcvode -lsundials_cvode -lsundials_fnvecserial -lsundials_nvecserial -lblas -llapack
 

--- a/tools/mech_converter.py
+++ b/tools/mech_converter.py
@@ -513,8 +513,6 @@ SUBROUTINE mechanism_rates (p, t, y, mnsp)
   INCLUDE 'modelConfiguration/mechanism-rate-coefficients.f90'
   RETURN
 END SUBROUTINE mechanism_rates
-
-INCLUDE 'utilityFunctions.f90'
 """)
     # print mechanism_rates_list
     with open(os.path.join(script_directory, '../mechanism-rates.f90'), 'w+') as mr2_file:


### PR DESCRIPTION
@rs028 Foolishly I pressed 'merge' on your PR before it had finished running Travis tests. In fact, it wouldn't compile on my Mac. This should fix that issue. I was seeing `duplicate symbol` errors for each of the functions in utilityFunctions.f90.