### PR TITLE
Improve getParametersFromFile()

### DIFF
--- a/atchem.f90
+++ b/atchem.f90
@@ -75,7 +75,9 @@ PROGRAM ATCHEM
 
   !   DECLARATIONS FOR CHEMICAL SPECIES CONSTRAINTS
   DOUBLE PRECISION, ALLOCATABLE :: z(:)
-  DOUBLE PRECISION solverParameters(100), modelParameters(100)
+  DOUBLE PRECISION tempForSolverParameters(100), tempForModelParameters(100)
+  DOUBLE PRECISION, ALLOCATABLE :: solverParameters(:), modelParameters(:)
+  INTEGER modelParameterSize, solverParameterSize
 
   DOUBLE PRECISION :: modelStartTime
 
@@ -265,13 +267,21 @@ PROGRAM ATCHEM
 
   !    READ IN SOLVER PARAMETERS
   WRITE (*,*) 'Reading solver parameters from file...'
-  CALL getParametersFromFile (trim(param_dir) // "/solver.parameters", solverParameters)
+  CALL getParametersFromFile (trim(param_dir) // "/solver.parameters", tempForSolverParameters, solverParameterSize)
   WRITE (*,*) 'Finished reading solver parameters from file.'
+  ALLOCATE (solverParameters(solverParameterSize))
+  DO i = 1, solverParameterSize
+     solverParameters(i) = tempForSolverParameters(i)
+  ENDDO
 
   !   READ IN MODEL PARAMETERS
   WRITE (*,*) 'Reading model parameters from file...'
-  CALL getParametersFromFile (trim(param_dir) //  "/model.parameters", modelParameters)
-  WRITE (*,*) 'Finished eading model parameters from file.'
+  CALL getParametersFromFile (trim(param_dir) //  "/model.parameters", tempForModelParameters, modelParameterSize)
+  WRITE (*,*) 'Finished reading model parameters from file.'
+  ALLOCATE (modelParameters(modelParameterSize))
+  DO i = 1, modelParameterSize
+     modelParameters(i) = tempForModelParameters(i)
+  ENDDO
   WRITE (*,*)
 
   !   SET SOLVER PARAMETERS

--- a/inputFunctions.f90
+++ b/inputFunctions.f90
@@ -152,18 +152,19 @@ SUBROUTINE getReactionListSizes (csize1, csize2)
 END SUBROUTINE getReactionListSizes
 
 
-SUBROUTINE getParametersFromFile (str, parameterArray)
-  CHARACTER :: str*(*)
-  DOUBLE PRECISION :: parameterArray(*)
-  INTEGER :: i
+SUBROUTINE getParametersFromFile (input_file, parameterArray, numValidEntries)
+  ! Read in parameters from file at input_file, and save the contents of each
+  ! line to an element of the array
+  CHARACTER, intent(in) :: input_file*(*)
+  DOUBLE PRECISION, intent(out) :: parameterArray(*)
+  INTEGER, intent(out) :: numValidEntries
 
-  ! READ IN SOLVER PARAMETERS
-  OPEN (10, file=str, status='old') ! input file
-  i = 1
-  READ (10,*) parameterArray(i)
-  DO WHILE (parameterArray(i)/=-9999)
-     i = i + 1
-     READ (10,*) parameterArray(i)
+  OPEN (10, file=input_file, status='old') ! input file
+  numValidEntries = 0
+  READ (10,*) parameterArray(1)
+  DO WHILE (parameterArray(numValidEntries+1)/=-9999)
+     numValidEntries = numValidEntries + 1
+     READ (10,*) parameterArray(numValidEntries+1)
   END DO
   CLOSE (10, status='keep')
 

--- a/travis/tests/full.out.cmp
+++ b/travis/tests/full.out.cmp
@@ -1,6 +1,6 @@
- Output dir is travis/tests/full                                                               
- Instantaneous rates dir is travis/tests/full/instantaneousRates                                            
- Parameter dir is travis/tests/full/modelConfiguration                                            
+ Output dir is travis/tests/full
+ Instantaneous rates dir is travis/tests/full/instantaneousRates
+ Parameter dir is travis/tests/full/modelConfiguration
 
  Number of Species =         5832
  Number of Reactions =        17224
@@ -14,51 +14,51 @@
  Finished reading species names.
 
  Reading initial concentrations...
-           1  H2O2          5000.0000000000000     
+           1  H2O2          5000.0000000000000
  ...
-           1  H2O2          5000.0000000000000     
+           1  H2O2          5000.0000000000000
  Finished reading initial concentrations.
 
  Looking for photolysis constants file...
  Photolysis constants file not found, trying photolysis rates file...
  Reading photolysis rates from file...
-           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000     
+           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000
  ...
-          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000     
+          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000
  Finished reading photolysis rates.
  Number of photolysis rates:          35
 
  Reading JFacSpecies...
- JFacSpecies =                               
+ JFacSpecies =
  Finished reading JFacSpecies.
 
  Reading products of interest...
-           1 OH        
-           2 HO2       
+           1 OH
+           2 HO2
  Finished reading products of interest.
  rateOfProdNS (number of species found):           2
 
  Reading reactants of interest...
-           1 OH        
-           2 HO2       
+           1 OH
+           2 HO2
  Finished reading reactants of interest.
  rateOfLossNS (number of species found):           2
 
  Reading solver parameters from file...
  Finished reading solver parameters from file.
  Reading model parameters from file...
- Finished eading model parameters from file.
+ Finished reading model parameters from file.
 
  Solver parameters:
  atol:    1.0000000000000000E-003 rtol:   1.0000000000000000E-004 JacVApprox:           0 deltaJv:   1.0000000000000000E-003
  deltaMain:   1.0000000000000000E-004 lookBack:         100 max_step:   100.00000000000000      precondBandUpper:         750 preconBandLower         750
- solverType:SPGMR + Banded Preconditioner           
+ solverType:SPGMR + Banded Preconditioner
 
  Model parameters:
- number of steps:            5 step size(seconds):   900.00000000000000     
- species interpolation method: piecewise linear                        
- conditions interpolation method: piecewise linear                        
- dec interpolation method: piecewise linear                        
+ number of steps:            5 step size(seconds):   900.00000000000000
+ species interpolation method: piecewise linear
+ conditions interpolation method: piecewise linear
+ dec interpolation method: piecewise linear
  maximum number of data points in constraint file:       10000
  maximum number of constrained species:          50
  ratesOutputStepSize        3600 instantaneous rates output step size:         900 modelStartTime:   3600.0000000000000      jacobianOutputStepSize:      108000
@@ -66,16 +66,16 @@
 
  Reading environment variables...
  Number of environment variables:           10
- 1                             M                             2.60e+19                      
- 2                             TEMP                          281.95e+00                    
- 3                             PRESS                         NOTUSED                       
- 4                             RH                            NOTUSED                       
- 5                             H2O                           3.06e+17                      
- 6                             DEC                           0.28782328e+00                
- 7                             BLHEIGHT           NOTUSED                       
- 8                             DILUTE                        6.77E-6                       
- 9                             JFAC                          NOTUSED                       
- 10                            ROOFOPEN                      NOTUSED                       
+ 1                             M                             2.60e+19
+ 2                             TEMP                          281.95e+00
+ 3                             PRESS                         NOTUSED
+ 4                             RH                            NOTUSED
+ 5                             H2O                           3.06e+17
+ 6                             DEC                           0.28782328e+00
+ 7                             BLHEIGHT           NOTUSED
+ 8                             DILUTE                        6.77E-6
+ 9                             JFAC                          NOTUSED
+ 10                            ROOFOPEN                      NOTUSED
  Finished reading environment variables.
 
  Checking for constrained environment variables...
@@ -84,15 +84,15 @@
  Reading concentration output from file...
  Finished reading concentration output from file.
  Output required for concentration of           2 species:
-           1 NO2       
-           2 HO2NO2    
+           1 NO2
+           2 HO2NO2
 
  Looking for photolysis constants file...
  Photolysis constants file not found, trying photolysis rates file...
  Reading photolysis rates from file...
-           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000     
+           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000
  ...
-          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000     
+          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000
  Finished reading photolysis rates.
  Number of photolysis rates:          35
 
@@ -121,7 +121,7 @@
  Finished initialising concentrations of constrained species.
 
  neq =         5832  numberOfConstrainedSpecies =            0
- t0 =    3600.0000000000000     
+ t0 =    3600.0000000000000
  setting maxsteps ier =            0
  time =         4500
  time =         5400

--- a/travis/tests/short.out.cmp
+++ b/travis/tests/short.out.cmp
@@ -1,6 +1,6 @@
- Output dir is travis/tests/short                                                              
- Instantaneous rates dir is travis/tests/short/instantaneousRates                                           
- Parameter dir is travis/tests/short/modelConfiguration                                           
+ Output dir is travis/tests/short
+ Instantaneous rates dir is travis/tests/short/instantaneousRates
+ Parameter dir is travis/tests/short/modelConfiguration
 
  Number of Species =          104
  Number of Reactions =          324
@@ -14,17 +14,17 @@
  Finished reading species names.
 
  Reading initial concentrations...
-           1  H2O2          5000.0000000000000     
+           1  H2O2          5000.0000000000000
  ...
-           1  H2O2          5000.0000000000000     
+           1  H2O2          5000.0000000000000
  Finished reading initial concentrations.
 
  Looking for photolysis constants file...
  Photolysis constants file not found, trying photolysis rates file...
  Reading photolysis rates from file...
-           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000     
+           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000
  ...
-          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000     
+          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000
  Finished reading photolysis rates.
  Number of photolysis rates:          35
 
@@ -33,32 +33,32 @@
  Finished reading JFacSpecies.
 
  Reading products of interest...
-           1 OH        
-           2 HO2       
+           1 OH
+           2 HO2
  Finished reading products of interest.
  rateOfProdNS (number of species found):           2
 
  Reading reactants of interest...
-           1 OH        
-           2 HO2       
+           1 OH
+           2 HO2
  Finished reading reactants of interest.
  rateOfLossNS (number of species found):           2
 
  Reading solver parameters from file...
  Finished reading solver parameters from file.
  Reading model parameters from file...
- Finished eading model parameters from file.
+ Finished reading model parameters from file.
 
  Solver parameters:
  atol:    1.0000000000000000E-003 rtol:   1.0000000000000000E-004 JacVApprox:           0 deltaJv:   1.0000000000000000E-003
  deltaMain:   1.0000000000000000E-004 lookBack:         100 max_step:   100.00000000000000      precondBandUpper:         750 preconBandLower         750
- solverType:SPGMR + Banded Preconditioner           
+ solverType:SPGMR + Banded Preconditioner
 
  Model parameters:
- number of steps:            5 step size(seconds):   900.00000000000000     
- species interpolation method: piecewise linear                        
- conditions interpolation method: piecewise linear                        
- dec interpolation method: piecewise linear                        
+ number of steps:            5 step size(seconds):   900.00000000000000
+ species interpolation method: piecewise linear
+ conditions interpolation method: piecewise linear
+ dec interpolation method: piecewise linear
  maximum number of data points in constraint file:       10000
  maximum number of constrained species:          50
  ratesOutputStepSize        3600 instantaneous rates output step size:         900 modelStartTime:   3600.0000000000000      jacobianOutputStepSize:      108000
@@ -66,16 +66,16 @@
 
  Reading environment variables...
  Number of environment variables:           10
- 1                             M                             2.60e+19                      
- 2                             TEMP                          281.95e+00                    
- 3                             PRESS                         NOTUSED                       
- 4                             RH                            NOTUSED                       
- 5                             H2O                           3.06e+17                      
- 6                             DEC                           0.28782328e+00                
- 7                             BLHEIGHT           NOTUSED                       
- 8                             DILUTE                        6.77E-6                       
- 9                             JFAC                          NOTUSED                       
- 10                            ROOFOPEN                      NOTUSED                       
+ 1                             M                             2.60e+19
+ 2                             TEMP                          281.95e+00
+ 3                             PRESS                         NOTUSED
+ 4                             RH                            NOTUSED
+ 5                             H2O                           3.06e+17
+ 6                             DEC                           0.28782328e+00
+ 7                             BLHEIGHT           NOTUSED
+ 8                             DILUTE                        6.77E-6
+ 9                             JFAC                          NOTUSED
+ 10                            ROOFOPEN                      NOTUSED
  Finished reading environment variables.
 
  Checking for constrained environment variables...
@@ -84,15 +84,15 @@
  Reading concentration output from file...
  Finished reading concentration output from file.
  Output required for concentration of           2 species:
-           1 NO2       
-           2 HO2NO2    
+           1 NO2
+           2 HO2NO2
 
  Looking for photolysis constants file...
  Photolysis constants file not found, trying photolysis rates file...
  Reading photolysis rates from file...
-           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000     
+           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000
  ...
-          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000     
+          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000
  Finished reading photolysis rates.
  Number of photolysis rates:          35
 
@@ -121,7 +121,7 @@
  Finished initialising concentrations of constrained species.
 
  neq =          104  numberOfConstrainedSpecies =            0
- t0 =    3600.0000000000000     
+ t0 =    3600.0000000000000
  setting maxsteps ier =            0
  time =         4500
  time =         5400

--- a/travis/tests/short_extended.out.cmp
+++ b/travis/tests/short_extended.out.cmp
@@ -1,6 +1,6 @@
- Output dir is travis/tests/short_extended                                                     
- Instantaneous rates dir is travis/tests/short_extended/instantaneousRates                                  
- Parameter dir is travis/tests/short_extended/modelConfiguration                                  
+ Output dir is travis/tests/short_extended
+ Instantaneous rates dir is travis/tests/short_extended/instantaneousRates
+ Parameter dir is travis/tests/short_extended/modelConfiguration
 
  Number of Species =          104
  Number of Reactions =          324
@@ -14,54 +14,54 @@
  Finished reading species names.
 
  Reading initial concentrations...
-           1  H2O2          5000.0000000000000     
+           1  H2O2          5000.0000000000000
  ...
-           1  H2O2          5000.0000000000000     
+           1  H2O2          5000.0000000000000
  Finished reading initial concentrations.
 
  Looking for photolysis constants file...
  Photolysis constants file not found, trying photolysis rates file...
  Reading photolysis rates from file...
-           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000     
+           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000
  ...
-          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000     
+          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000
  Finished reading photolysis rates.
  Number of photolysis rates:          35
 
  Reading JFacSpecies...
  No JFacSpecies.config file exists, so setting jFacSpecies to ''
- JFacSpecies =                               
+ JFacSpecies =
  Finished reading JFacSpecies.
 
  Reading products of interest...
-           1 OH        
+           1 OH
  ...
-           6 HOCH2CO3H 
+           6 HOCH2CO3H
  Finished reading products of interest.
  rateOfProdNS (number of species found):           6
 
  Reading reactants of interest...
-           1 OH        
+           1 OH
  ...
-           5 HOCH2CO3H 
+           5 HOCH2CO3H
  Finished reading reactants of interest.
  rateOfLossNS (number of species found):           5
 
  Reading solver parameters from file...
  Finished reading solver parameters from file.
  Reading model parameters from file...
- Finished eading model parameters from file.
+ Finished reading model parameters from file.
 
  Solver parameters:
  atol:    1.0000000000000000E-003 rtol:   1.0000000000000000E-004 JacVApprox:           0 deltaJv:   1.0000000000000000E-003
  deltaMain:   1.0000000000000000E-004 lookBack:         100 max_step:   100.00000000000000      precondBandUpper:         750 preconBandLower         750
- solverType:SPGMR + Banded Preconditioner           
+ solverType:SPGMR + Banded Preconditioner
 
  Model parameters:
- number of steps:            3 step size(seconds):   1000.0000000000000     
- species interpolation method: piecewise linear                        
- conditions interpolation method: piecewise linear                        
- dec interpolation method: piecewise linear                        
+ number of steps:            3 step size(seconds):   1000.0000000000000
+ species interpolation method: piecewise linear
+ conditions interpolation method: piecewise linear
+ dec interpolation method: piecewise linear
  maximum number of data points in constraint file:       10000
  maximum number of constrained species:          50
  ratesOutputStepSize        3000 instantaneous rates output step size:         900 modelStartTime:   3600.0000000000000      jacobianOutputStepSize:      108000
@@ -69,16 +69,16 @@
 
  Reading environment variables...
  Number of environment variables:           10
- 1                             M                             2.60e+19                      
- 2                             TEMP                          281.95e+00                    
- 3                             PRESS                         NOTUSED                       
- 4                             RH                            NOTUSED                       
- 5                             H2O                           3.06e+17                      
- 6                             DEC                           0.28782328e+00                
- 7                             BLHEIGHT           NOTUSED                       
- 8                             DILUTE                        6.77E-6                       
- 9                             JFAC                          NOTUSED                       
- 10                            ROOFOPEN                      NOTUSED                       
+ 1                             M                             2.60e+19
+ 2                             TEMP                          281.95e+00
+ 3                             PRESS                         NOTUSED
+ 4                             RH                            NOTUSED
+ 5                             H2O                           3.06e+17
+ 6                             DEC                           0.28782328e+00
+ 7                             BLHEIGHT           NOTUSED
+ 8                             DILUTE                        6.77E-6
+ 9                             JFAC                          NOTUSED
+ 10                            ROOFOPEN                      NOTUSED
  Finished reading environment variables.
 
  Checking for constrained environment variables...
@@ -87,16 +87,16 @@
  Reading concentration output from file...
  Finished reading concentration output from file.
  Output required for concentration of           4 species:
-           1 NO2       
+           1 NO2
  ...
            4 HOCO3C4OOH
 
  Looking for photolysis constants file...
  Photolysis constants file not found, trying photolysis rates file...
  Reading photolysis rates from file...
-           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000     
+           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000
  ...
-          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000     
+          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000
  Finished reading photolysis rates.
  Number of photolysis rates:          35
 
@@ -125,7 +125,7 @@
  Finished initialising concentrations of constrained species.
 
  neq =          104  numberOfConstrainedSpecies =            0
- t0 =    3600.0000000000000     
+ t0 =    3600.0000000000000
  setting maxsteps ier =            0
  time =         4600
  time =         5600


### PR DESCRIPTION
Improve getParametersFromFile() by only writing to a temporary array and outputting the valid size - this is then copied into an allocatable array of exactly the correct size. Add comments. Fix a typo in output files.