### PR TITLE
Neaten sections of screen output.

### DIFF
--- a/atchem.f90
+++ b/atchem.f90
@@ -290,11 +290,23 @@ PROGRAM ATCHEM
   preconBandUpper = solverParameters(9)
   preconBandLower = solverParameters(10)
 
+  ! float format
+100 FORMAT (A17, E11.3)
+  ! integer format
+200 FORMAT (A17, I11)
   WRITE (*,*) 'Solver parameters:'
-  WRITE (*,*) 'atol: ', atol, 'rtol:', rtol, 'JacVApprox:', JvApprox, 'deltaJv:', deltaJv
-  WRITE (*,*) 'deltaMain:', deltaMain, 'lookBack:', lookBack, 'max_step:', max_step, &
-       'precondBandUpper:', preconBandUpper, 'preconBandLower', preconBandLower
-  WRITE (*,*) 'solverType:', solverTypeName(solverType)
+  WRITE (*,*) '------------------'
+  WRITE (*,100) 'atol: ', atol
+  WRITE (*,100) 'rtol: ', rtol
+  WRITE (*,200) 'JacVApprox: ', JvApprox
+  WRITE (*,100) 'deltaJv: ', deltaJv
+  WRITE (*,100) 'deltaMain: ', deltaMain
+  WRITE (*,200) 'lookBack: ', lookBack
+  WRITE (*,100) 'max_step: ', max_step
+  WRITE (*,200) 'preconBandUpper: ', preconBandUpper
+  WRITE (*,200) 'preconBandLower: ', preconBandLower
+  WRITE (*,'(A17, A29)') 'solverType: ', adjustl(solverTypeName(solverType))
+  WRITE (*,*) '------------------'
   WRITE (*,*)
 
   !   SET MODEL PARAMETERS
@@ -318,18 +330,29 @@ PROGRAM ATCHEM
   year = modelParameters(15)
   irOutStepSize = modelParameters(16)
 
+  ! float format
+300 FORMAT (A52, E11.3)
+  ! integer format
+400 FORMAT (A52, I11)
+  ! string format
+500 FORMAT (A52, A17)
   WRITE (*,*) 'Model parameters:'
-  WRITE (*,*) 'number of steps: ', nout, 'step size(seconds):', tout
-  WRITE (*,*) 'species interpolation method: ', interpolationMethodName(speciesInterpMethod)
-  WRITE (*,*) 'conditions interpolation method: ', interpolationMethodName(conditionsInterpMethod)
-  WRITE (*,*) 'dec interpolation method: ', interpolationMethodName(decInterpMethod)
-  WRITE (*,*) 'maximum number of data points in constraint file:', maxNumberOfDataPoints
-  WRITE (*,*) 'maximum number of constrained species:', numberOfConstrainedSpecies
-  WRITE (*,*) 'ratesOutputStepSize', ratesOutputStepSize, &
-       'instantaneous rates output step size:', irOutStepSize, &
-       'modelStartTime:', modelStartTime, 'jacobianOutputStepSize:', jacobianOutputStepSize
-  WRITE (*,*) 'latitude:', latitude, 'longitude:', longitude, &
-       'day/month/year:', day, month, year
+  WRITE (*,*) '-----------------'
+  WRITE (*,400) 'number of steps: ', nout
+  WRITE (*,300) 'step size (seconds): ', tout
+  WRITE (*,500) 'species interpolation method: ', adjustl(interpolationMethodName(speciesInterpMethod))
+  WRITE (*,500) 'conditions interpolation method: ', adjustl(interpolationMethodName(conditionsInterpMethod))
+  WRITE (*,500) 'dec interpolation method: ', adjustl(interpolationMethodName(decInterpMethod))
+  WRITE (*,400) 'maximum number of data points in constraint file: ', maxNumberOfDataPoints
+  WRITE (*,400) 'maximum number of constrained species: ', numberOfConstrainedSpecies
+  WRITE (*,400) 'ratesOutputStepSize: ', ratesOutputStepSize
+  WRITE (*,400) 'instantaneous rates output step size: ', irOutStepSize
+  WRITE (*,300) 'modelStartTime: ', modelStartTime
+  WRITE (*,400) 'jacobianOutputStepSize: ', jacobianOutputStepSize
+  WRITE (*,300) 'latitude: ', latitude
+  WRITE (*,300) 'longitude: ', longitude
+  WRITE (*,'(A52, I3, A, I2, A, I4)') 'day/month/year: ', day, '/', month, '/', year
+  WRITE (*,*) '-----------------'
   WRITE (*,*)
 
   CALL calcDateParameters ()
@@ -395,7 +418,8 @@ PROGRAM ATCHEM
 
   !   ADJUST PROBLEM SPECIFICATION TO GIVE NUMBER OF SPECIES TO BE SOLVED FOR (N - C = M)
   neq = numSpec - numberOfConstrainedSpecies
-  WRITE (*,*) 'neq = ', neq, ' numberOfConstrainedSpecies = ', numberOfConstrainedSpecies
+  WRITE (*,'(A30, I6)') 'neq = ', neq
+  WRITE (*,'(A30, I6)') 'numberOfConstrainedSpecies = ', numberOfConstrainedSpecies
 
   flush(stderr)
 
@@ -413,7 +437,7 @@ PROGRAM ATCHEM
      STOP
   ENDIF
 
-  WRITE (*,*) 't0 = ', t0
+  WRITE (*,'(A30, E15.3)') 't0 = ', t0
   CALL fcvmalloc (t0, z, meth, itmeth, itol, rtol, atol, &
        iout, rout, ipar, rpar, ier)
   IF (ier/=0) THEN

--- a/inputFunctions.f90
+++ b/inputFunctions.f90
@@ -323,10 +323,17 @@ SUBROUTINE readConcentrations (concSpeciesName, concentration, concCounter, nsp)
   ENDDO
   CLOSE (10, status='keep')
 
-  WRITE (*,*) 1, ' ', concSpeciesName(1), ' ', concentration(1)
-  WRITE (*,*) '...'
-  WRITE (*,*) concCounter, ' ', concSpeciesName(concCounter), ' ', concentration(concCounter)
-
+  IF (concCounter>0) THEN
+     WRITE (*,*) 1, ' ', concSpeciesName(1), ' ', concentration(1)
+  ENDIF
+  IF (concCounter>3) THEN
+     WRITE (*,*) '...'
+  ELSE IF (concCounter==3) THEN
+     WRITE (*,*) 2, ' ', concSpeciesName(2), ' ', concentration(2)
+  ENDIF
+  IF (concCounter>1) THEN
+     WRITE (*,*) concCounter, ' ', concSpeciesName(concCounter), ' ', concentration(concCounter)
+  ENDIF
   WRITE (*,*) 'Finished reading initial concentrations.'
 
   IF (concCounter>nsp) THEN
@@ -370,8 +377,10 @@ SUBROUTINE readProductsOfInterest (r, i)
   IF (i>0) THEN
      WRITE (*,*) 1, r(1)
   ENDIF
-  IF (i>2) THEN
+  IF (i>3) THEN
      WRITE (*,*) '...'
+  ELSE IF (i==3) THEN
+     WRITE (*,*) 2, r(2)
   ENDIF
   IF (i>1) THEN
      WRITE (*,*) i, r(i)
@@ -412,8 +421,10 @@ SUBROUTINE readReactantsOfInterest (r, i)
   IF (i>0) THEN
      WRITE (*,*) 1, r(1)
   ENDIF
-  IF (i>2) THEN
+  IF (i>3) THEN
      WRITE (*,*) '...'
+  ELSE IF (i==3) THEN
+     WRITE (*,*) 2, r(2)
   ENDIF
   IF (i>1) THEN
      WRITE (*,*) i, r(i)
@@ -642,7 +653,7 @@ SUBROUTINE readEnvVar (maxNumberOfDataPoints)
   numConEnvVar = 0
   DO i = 1, numEnvVars
      READ (10,*) dummy, envVarNames(i), envVarTypes(i)
-     WRITE (*,*) dummy, envVarNames(i), envVarTypes(i)
+     WRITE (*,'(A, A4, A12, A30)') ' ', dummy, envVarNames(i), adjustr(envVarTypes(i))
 
      IF (trim(envVarTypes(i))=='CALC') THEN
         envVarTypesNum(i) = 1

--- a/travis/tests/full.out.cmp
+++ b/travis/tests/full.out.cmp
@@ -1,6 +1,6 @@
- Output dir is travis/tests/full
- Instantaneous rates dir is travis/tests/full/instantaneousRates
- Parameter dir is travis/tests/full/modelConfiguration
+ Output dir is travis/tests/full                                                               
+ Instantaneous rates dir is travis/tests/full/instantaneousRates                                            
+ Parameter dir is travis/tests/full/modelConfiguration                                            
 
  Number of Species =         5832
  Number of Reactions =        17224
@@ -14,33 +14,31 @@
  Finished reading species names.
 
  Reading initial concentrations...
-           1  H2O2          5000.0000000000000
- ...
-           1  H2O2          5000.0000000000000
+           1  H2O2          5000.0000000000000     
  Finished reading initial concentrations.
 
  Looking for photolysis constants file...
  Photolysis constants file not found, trying photolysis rates file...
  Reading photolysis rates from file...
-           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000
+           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000     
  ...
-          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000
+          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000     
  Finished reading photolysis rates.
  Number of photolysis rates:          35
 
  Reading JFacSpecies...
- JFacSpecies =
+ JFacSpecies = 
  Finished reading JFacSpecies.
 
  Reading products of interest...
-           1 OH
-           2 HO2
+           1 OH        
+           2 HO2       
  Finished reading products of interest.
  rateOfProdNS (number of species found):           2
 
  Reading reactants of interest...
-           1 OH
-           2 HO2
+           1 OH        
+           2 HO2       
  Finished reading reactants of interest.
  rateOfLossNS (number of species found):           2
 
@@ -50,32 +48,49 @@
  Finished reading model parameters from file.
 
  Solver parameters:
- atol:    1.0000000000000000E-003 rtol:   1.0000000000000000E-004 JacVApprox:           0 deltaJv:   1.0000000000000000E-003
- deltaMain:   1.0000000000000000E-004 lookBack:         100 max_step:   100.00000000000000      precondBandUpper:         750 preconBandLower         750
- solverType:SPGMR + Banded Preconditioner
+ ------------------
+           atol:   0.100E-02
+           rtol:   0.100E-03
+     JacVApprox:           0
+        deltaJv:   0.100E-02
+      deltaMain:   0.100E-03
+       lookBack:         100
+       max_step:   0.100E+03
+preconBandUpper:         750
+preconBandLower:         750
+     solverType: SPGMR + Banded Preconditioner
+ ------------------
 
  Model parameters:
- number of steps:            5 step size(seconds):   900.00000000000000
- species interpolation method: piecewise linear
- conditions interpolation method: piecewise linear
- dec interpolation method: piecewise linear
- maximum number of data points in constraint file:       10000
- maximum number of constrained species:          50
- ratesOutputStepSize        3600 instantaneous rates output step size:         900 modelStartTime:   3600.0000000000000      jacobianOutputStepSize:      108000
- latitude:   52.942999999999998      longitude:   0.0000000000000000      day/month/year:          19          11        2008
+ -----------------
+                                   number of steps:           5
+                               step size (seconds):   0.900E+03
+                      species interpolation method: piecewise linear 
+                   conditions interpolation method: piecewise linear 
+                          dec interpolation method: piecewise linear 
+  maximum number of data points in constraint file:       10000
+             maximum number of constrained species:          50
+                               ratesOutputStepSize:        3600
+              instantaneous rates output step size:         900
+                                    modelStartTime:   0.360E+04
+                            jacobianOutputStepSize:      108000
+                                          latitude:   0.529E+02
+                                         longitude:   0.000E+00
+                                    day/month/year:  19/11/2008
+ -----------------
 
  Reading environment variables...
  Number of environment variables:           10
- 1                             M                             2.60e+19
- 2                             TEMP                          281.95e+00
- 3                             PRESS                         NOTUSED
- 4                             RH                            NOTUSED
- 5                             H2O                           3.06e+17
- 6                             DEC                           0.28782328e+00
- 7                             BLHEIGHT           NOTUSED
- 8                             DILUTE                        6.77E-6
- 9                             JFAC                          NOTUSED
- 10                            ROOFOPEN                      NOTUSED
+ 1   M                                 2.60e+19
+ 2   TEMP                            281.95e+00
+ 3   PRESS                              NOTUSED
+ 4   RH                                 NOTUSED
+ 5   H2O                               3.06e+17
+ 6   DEC                         0.28782328e+00
+ 7   BLHEIGHT                           NOTUSED
+ 8   DILUTE                             6.77E-6
+ 9   JFAC                               NOTUSED
+ 10  ROOFOPEN                           NOTUSED
  Finished reading environment variables.
 
  Checking for constrained environment variables...
@@ -84,15 +99,15 @@
  Reading concentration output from file...
  Finished reading concentration output from file.
  Output required for concentration of           2 species:
-           1 NO2
-           2 HO2NO2
+           1 NO2       
+           2 HO2NO2    
 
  Looking for photolysis constants file...
  Photolysis constants file not found, trying photolysis rates file...
  Reading photolysis rates from file...
-           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000
+           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000     
  ...
-          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000
+          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000     
  Finished reading photolysis rates.
  Number of photolysis rates:          35
 
@@ -120,8 +135,9 @@
  Initialising concentrations of constrained species...
  Finished initialising concentrations of constrained species.
 
- neq =         5832  numberOfConstrainedSpecies =            0
- t0 =    3600.0000000000000
+                        neq =   5832
+ numberOfConstrainedSpecies =      0
+                         t0 =       0.360E+04
  setting maxsteps ier =            0
  time =         4500
  time =         5400
@@ -137,5 +153,5 @@ Final statistics:
  No. nonlinear convergence failures =    0
  No. error test failures =    0
 
- Runtime =           12
+ Runtime =           13
  Deallocating memory.

--- a/travis/tests/short.out.cmp
+++ b/travis/tests/short.out.cmp
@@ -1,6 +1,6 @@
- Output dir is travis/tests/short
- Instantaneous rates dir is travis/tests/short/instantaneousRates
- Parameter dir is travis/tests/short/modelConfiguration
+ Output dir is travis/tests/short                                                              
+ Instantaneous rates dir is travis/tests/short/instantaneousRates                                           
+ Parameter dir is travis/tests/short/modelConfiguration                                           
 
  Number of Species =          104
  Number of Reactions =          324
@@ -14,33 +14,31 @@
  Finished reading species names.
 
  Reading initial concentrations...
-           1  H2O2          5000.0000000000000
- ...
-           1  H2O2          5000.0000000000000
+           1  H2O2          5000.0000000000000     
  Finished reading initial concentrations.
 
  Looking for photolysis constants file...
  Photolysis constants file not found, trying photolysis rates file...
  Reading photolysis rates from file...
-           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000
+           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000     
  ...
-          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000
+          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000     
  Finished reading photolysis rates.
  Number of photolysis rates:          35
 
  Reading JFacSpecies...
- JFacSpecies =
+ JFacSpecies = 
  Finished reading JFacSpecies.
 
  Reading products of interest...
-           1 OH
-           2 HO2
+           1 OH        
+           2 HO2       
  Finished reading products of interest.
  rateOfProdNS (number of species found):           2
 
  Reading reactants of interest...
-           1 OH
-           2 HO2
+           1 OH        
+           2 HO2       
  Finished reading reactants of interest.
  rateOfLossNS (number of species found):           2
 
@@ -50,32 +48,49 @@
  Finished reading model parameters from file.
 
  Solver parameters:
- atol:    1.0000000000000000E-003 rtol:   1.0000000000000000E-004 JacVApprox:           0 deltaJv:   1.0000000000000000E-003
- deltaMain:   1.0000000000000000E-004 lookBack:         100 max_step:   100.00000000000000      precondBandUpper:         750 preconBandLower         750
- solverType:SPGMR + Banded Preconditioner
+ ------------------
+           atol:   0.100E-02
+           rtol:   0.100E-03
+     JacVApprox:           0
+        deltaJv:   0.100E-02
+      deltaMain:   0.100E-03
+       lookBack:         100
+       max_step:   0.100E+03
+preconBandUpper:         750
+preconBandLower:         750
+     solverType: SPGMR + Banded Preconditioner
+ ------------------
 
  Model parameters:
- number of steps:            5 step size(seconds):   900.00000000000000
- species interpolation method: piecewise linear
- conditions interpolation method: piecewise linear
- dec interpolation method: piecewise linear
- maximum number of data points in constraint file:       10000
- maximum number of constrained species:          50
- ratesOutputStepSize        3600 instantaneous rates output step size:         900 modelStartTime:   3600.0000000000000      jacobianOutputStepSize:      108000
- latitude:   52.942999999999998      longitude:   0.0000000000000000      day/month/year:          19          11        2008
+ -----------------
+                                   number of steps:           5
+                               step size (seconds):   0.900E+03
+                      species interpolation method: piecewise linear 
+                   conditions interpolation method: piecewise linear 
+                          dec interpolation method: piecewise linear 
+  maximum number of data points in constraint file:       10000
+             maximum number of constrained species:          50
+                               ratesOutputStepSize:        3600
+              instantaneous rates output step size:         900
+                                    modelStartTime:   0.360E+04
+                            jacobianOutputStepSize:      108000
+                                          latitude:   0.529E+02
+                                         longitude:   0.000E+00
+                                    day/month/year:  19/11/2008
+ -----------------
 
  Reading environment variables...
  Number of environment variables:           10
- 1                             M                             2.60e+19
- 2                             TEMP                          281.95e+00
- 3                             PRESS                         NOTUSED
- 4                             RH                            NOTUSED
- 5                             H2O                           3.06e+17
- 6                             DEC                           0.28782328e+00
- 7                             BLHEIGHT           NOTUSED
- 8                             DILUTE                        6.77E-6
- 9                             JFAC                          NOTUSED
- 10                            ROOFOPEN                      NOTUSED
+ 1   M                                 2.60e+19
+ 2   TEMP                            281.95e+00
+ 3   PRESS                              NOTUSED
+ 4   RH                                 NOTUSED
+ 5   H2O                               3.06e+17
+ 6   DEC                         0.28782328e+00
+ 7   BLHEIGHT                           NOTUSED
+ 8   DILUTE                             6.77E-6
+ 9   JFAC                               NOTUSED
+ 10  ROOFOPEN                           NOTUSED
  Finished reading environment variables.
 
  Checking for constrained environment variables...
@@ -84,15 +99,15 @@
  Reading concentration output from file...
  Finished reading concentration output from file.
  Output required for concentration of           2 species:
-           1 NO2
-           2 HO2NO2
+           1 NO2       
+           2 HO2NO2    
 
  Looking for photolysis constants file...
  Photolysis constants file not found, trying photolysis rates file...
  Reading photolysis rates from file...
-           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000
+           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000     
  ...
-          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000
+          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000     
  Finished reading photolysis rates.
  Number of photolysis rates:          35
 
@@ -120,8 +135,9 @@
  Initialising concentrations of constrained species...
  Finished initialising concentrations of constrained species.
 
- neq =          104  numberOfConstrainedSpecies =            0
- t0 =    3600.0000000000000
+                        neq =    104
+ numberOfConstrainedSpecies =      0
+                         t0 =       0.360E+04
  setting maxsteps ier =            0
  time =         4500
  time =         5400

--- a/travis/tests/short_extended.out.cmp
+++ b/travis/tests/short_extended.out.cmp
@@ -1,6 +1,6 @@
- Output dir is travis/tests/short_extended
- Instantaneous rates dir is travis/tests/short_extended/instantaneousRates
- Parameter dir is travis/tests/short_extended/modelConfiguration
+ Output dir is travis/tests/short_extended                                                     
+ Instantaneous rates dir is travis/tests/short_extended/instantaneousRates                                  
+ Parameter dir is travis/tests/short_extended/modelConfiguration                                  
 
  Number of Species =          104
  Number of Reactions =          324
@@ -14,36 +14,34 @@
  Finished reading species names.
 
  Reading initial concentrations...
-           1  H2O2          5000.0000000000000
- ...
-           1  H2O2          5000.0000000000000
+           1  H2O2          5000.0000000000000     
  Finished reading initial concentrations.
 
  Looking for photolysis constants file...
  Photolysis constants file not found, trying photolysis rates file...
  Reading photolysis rates from file...
-           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000
+           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000     
  ...
-          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000
+          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000     
  Finished reading photolysis rates.
  Number of photolysis rates:          35
 
  Reading JFacSpecies...
  No JFacSpecies.config file exists, so setting jFacSpecies to ''
- JFacSpecies =
+ JFacSpecies = 
  Finished reading JFacSpecies.
 
  Reading products of interest...
-           1 OH
+           1 OH        
  ...
-           6 HOCH2CO3H
+           6 HOCH2CO3H 
  Finished reading products of interest.
  rateOfProdNS (number of species found):           6
 
  Reading reactants of interest...
-           1 OH
+           1 OH        
  ...
-           5 HOCH2CO3H
+           5 HOCH2CO3H 
  Finished reading reactants of interest.
  rateOfLossNS (number of species found):           5
 
@@ -53,32 +51,49 @@
  Finished reading model parameters from file.
 
  Solver parameters:
- atol:    1.0000000000000000E-003 rtol:   1.0000000000000000E-004 JacVApprox:           0 deltaJv:   1.0000000000000000E-003
- deltaMain:   1.0000000000000000E-004 lookBack:         100 max_step:   100.00000000000000      precondBandUpper:         750 preconBandLower         750
- solverType:SPGMR + Banded Preconditioner
+ ------------------
+           atol:   0.100E-02
+           rtol:   0.100E-03
+     JacVApprox:           0
+        deltaJv:   0.100E-02
+      deltaMain:   0.100E-03
+       lookBack:         100
+       max_step:   0.100E+03
+preconBandUpper:         750
+preconBandLower:         750
+     solverType: SPGMR + Banded Preconditioner
+ ------------------
 
  Model parameters:
- number of steps:            3 step size(seconds):   1000.0000000000000
- species interpolation method: piecewise linear
- conditions interpolation method: piecewise linear
- dec interpolation method: piecewise linear
- maximum number of data points in constraint file:       10000
- maximum number of constrained species:          50
- ratesOutputStepSize        3000 instantaneous rates output step size:         900 modelStartTime:   3600.0000000000000      jacobianOutputStepSize:      108000
- latitude:   52.942999999999998      longitude:   0.0000000000000000      day/month/year:          19          11        2008
+ -----------------
+                                   number of steps:           3
+                               step size (seconds):   0.100E+04
+                      species interpolation method: piecewise linear 
+                   conditions interpolation method: piecewise linear 
+                          dec interpolation method: piecewise linear 
+  maximum number of data points in constraint file:       10000
+             maximum number of constrained species:          50
+                               ratesOutputStepSize:        3000
+              instantaneous rates output step size:         900
+                                    modelStartTime:   0.360E+04
+                            jacobianOutputStepSize:      108000
+                                          latitude:   0.529E+02
+                                         longitude:   0.000E+00
+                                    day/month/year:  19/11/2008
+ -----------------
 
  Reading environment variables...
  Number of environment variables:           10
- 1                             M                             2.60e+19
- 2                             TEMP                          281.95e+00
- 3                             PRESS                         NOTUSED
- 4                             RH                            NOTUSED
- 5                             H2O                           3.06e+17
- 6                             DEC                           0.28782328e+00
- 7                             BLHEIGHT           NOTUSED
- 8                             DILUTE                        6.77E-6
- 9                             JFAC                          NOTUSED
- 10                            ROOFOPEN                      NOTUSED
+ 1   M                                 2.60e+19
+ 2   TEMP                            281.95e+00
+ 3   PRESS                              NOTUSED
+ 4   RH                                 NOTUSED
+ 5   H2O                               3.06e+17
+ 6   DEC                         0.28782328e+00
+ 7   BLHEIGHT                           NOTUSED
+ 8   DILUTE                             6.77E-6
+ 9   JFAC                               NOTUSED
+ 10  ROOFOPEN                           NOTUSED
  Finished reading environment variables.
 
  Checking for constrained environment variables...
@@ -87,16 +102,16 @@
  Reading concentration output from file...
  Finished reading concentration output from file.
  Output required for concentration of           4 species:
-           1 NO2
+           1 NO2       
  ...
            4 HOCO3C4OOH
 
  Looking for photolysis constants file...
  Photolysis constants file not found, trying photolysis rates file...
  Reading photolysis rates from file...
-           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000
+           1   6.0730000000000003E-005   1.7430000000000001       0.47399999999999998      J1                               1.0000000000000000     
  ...
-          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000
+          61   7.5370000000000005E-004  0.49900000000000000       0.26600000000000001      J61                              1.0000000000000000     
  Finished reading photolysis rates.
  Number of photolysis rates:          35
 
@@ -124,8 +139,9 @@
  Initialising concentrations of constrained species...
  Finished initialising concentrations of constrained species.
 
- neq =          104  numberOfConstrainedSpecies =            0
- t0 =    3600.0000000000000
+                        neq =    104
+ numberOfConstrainedSpecies =      0
+                         t0 =       0.360E+04
  setting maxsteps ier =            0
  time =         4600
  time =         5600

--- a/travis/tests/single_reac_of_interest.out.cmp
+++ b/travis/tests/single_reac_of_interest.out.cmp
@@ -15,8 +15,6 @@
 
  Reading initial concentrations...
            1  H2O2          5000.0000000000000     
- ...
-           1  H2O2          5000.0000000000000     
  Finished reading initial concentrations.
 
  Looking for photolysis constants file...
@@ -49,32 +47,49 @@
  Finished reading model parameters from file.
 
  Solver parameters:
- atol:    1.0000000000000000E-003 rtol:   1.0000000000000000E-004 JacVApprox:           0 deltaJv:   1.0000000000000000E-003
- deltaMain:   1.0000000000000000E-004 lookBack:         100 max_step:   100.00000000000000      precondBandUpper:         750 preconBandLower         750
- solverType:SPGMR + Banded Preconditioner           
+ ------------------
+           atol:   0.100E-02
+           rtol:   0.100E-03
+     JacVApprox:           0
+        deltaJv:   0.100E-02
+      deltaMain:   0.100E-03
+       lookBack:         100
+       max_step:   0.100E+03
+preconBandUpper:         750
+preconBandLower:         750
+     solverType: SPGMR + Banded Preconditioner
+ ------------------
 
  Model parameters:
- number of steps:            3 step size(seconds):   1000.0000000000000     
- species interpolation method: piecewise linear                        
- conditions interpolation method: piecewise linear                        
- dec interpolation method: piecewise linear                        
- maximum number of data points in constraint file:       10000
- maximum number of constrained species:          50
- ratesOutputStepSize        3000 instantaneous rates output step size:         900 modelStartTime:   3600.0000000000000      jacobianOutputStepSize:      108000
- latitude:   52.942999999999998      longitude:   0.0000000000000000      day/month/year:          19          11        2008
+ -----------------
+                                   number of steps:           3
+                               step size (seconds):   0.100E+04
+                      species interpolation method: piecewise linear 
+                   conditions interpolation method: piecewise linear 
+                          dec interpolation method: piecewise linear 
+  maximum number of data points in constraint file:       10000
+             maximum number of constrained species:          50
+                               ratesOutputStepSize:        3000
+              instantaneous rates output step size:         900
+                                    modelStartTime:   0.360E+04
+                            jacobianOutputStepSize:      108000
+                                          latitude:   0.529E+02
+                                         longitude:   0.000E+00
+                                    day/month/year:  19/11/2008
+ -----------------
 
  Reading environment variables...
  Number of environment variables:           10
- 1                             M                             2.60e+19                      
- 2                             TEMP                          281.95e+00                    
- 3                             PRESS                         NOTUSED                       
- 4                             RH                            NOTUSED                       
- 5                             H2O                           3.06e+17                      
- 6                             DEC                           0.28782328e+00                
- 7                             BLHEIGHT                      NOTUSED                       
- 8                             DILUTE                        6.77E-6                       
- 9                             JFAC                          NOTUSED                       
- 10                            ROOFOPEN                      NOTUSED                       
+ 1   M                                 2.60e+19
+ 2   TEMP                            281.95e+00
+ 3   PRESS                              NOTUSED
+ 4   RH                                 NOTUSED
+ 5   H2O                               3.06e+17
+ 6   DEC                         0.28782328e+00
+ 7   BLHEIGHT                           NOTUSED
+ 8   DILUTE                             6.77E-6
+ 9   JFAC                               NOTUSED
+ 10  ROOFOPEN                           NOTUSED
  Finished reading environment variables.
 
  Checking for constrained environment variables...
@@ -120,8 +135,9 @@
  Initialising concentrations of constrained species...
  Finished initialising concentrations of constrained species.
 
- neq =          104  numberOfConstrainedSpecies =            0
- t0 =    3600.0000000000000     
+                        neq =    104
+ numberOfConstrainedSpecies =      0
+                         t0 =       0.360E+04
  setting maxsteps ier =            0
  time =         4600
  time =         5600


### PR DESCRIPTION
Change the output to neaten up the solver parameter and model parameter sections, and the final bit before the timestepping. Also change the behaviour when listing read-in species: when there are <= 3 species, print them all, otherwise print first and last, separated by an ellipsis.

Edit expected test outputs appropriately.