### PR TITLE
outputInstantaneousRates

### DIFF
--- a/atchem.f90
+++ b/atchem.f90
@@ -83,9 +83,7 @@ PROGRAM ATCHEM
   CHARACTER (LEN=400) :: fmt
 
   !   DECLARATIONS FOR IR OUTPUT
-  CHARACTER (LEN=57) :: irfileLocation
   INTEGER :: irOutStepSize
-  CHARACTER (LEN=30) :: strTime
 
   INTEGER :: cmd_arg_count
   !    MISC
@@ -595,15 +593,7 @@ PROGRAM ATCHEM
 
      !OUTPUT INSTANTANEOUS RATES
      IF (MOD (elapsed, irOutStepSize)==0) THEN
-        WRITE (strTime,*) time
-
-        irfileLocation = trim(instantaneousRates_dir) // '/' // ADJUSTL (strTime)
-
-        OPEN (10, file=irfileLocation)
-        DO i = 1, numReactions
-           WRITE (10,*) ir(i)
-        ENDDO
-        CLOSE (10, status='keep')
+        CALL outputInstantaneousRates(time, numReactions)
      ENDIF
 
      ! OUTPUT FOR CVODE MAIN SOLVER

--- a/outputFunctions.f90
+++ b/outputFunctions.f90
@@ -150,6 +150,31 @@ SUBROUTINE outputRates (r, t, p, flag, numberOfSpecies, csize, arrayLen, &
   RETURN
 END SUBROUTINE outputRates
 
+SUBROUTINE outputInstantaneousRates (time, numReac)
+
+  USE reactionStructure
+  USE directories, ONLY : instantaneousRates_dir
+  USE productionAndLossRates, ONLY : ir
+  USE, INTRINSIC :: iso_fortran_env, ONLY : stderr=>error_unit
+
+  INTEGER, intent(in) :: time, numReac
+  INTEGER i
+  CHARACTER (LEN=57) :: irfileLocation
+  CHARACTER (LEN=30) :: strTime
+
+  WRITE (strTime,*) time
+
+  irfileLocation = trim(instantaneousRates_dir) // '/' // ADJUSTL (strTime)
+
+  OPEN (10, file=irfileLocation)
+  DO i = 1, numReac
+     WRITE (10,*) ir(i)
+  ENDDO
+  CLOSE (10, status='keep')
+
+  RETURN
+END SUBROUTINE outputInstantaneousRates
+
 !     ----------------------------------------------------------------
 SUBROUTINE outputSpeciesOutputRequiredNames (names, namesSize)
   CHARACTER (LEN=10) names(*)


### PR DESCRIPTION
Move code for output of instantaneous rates to a new subroutine outputInstantaneousRates(), more consistent with the existing outputjfy() and outputRates().