### PR TITLE
Use module member, not function argument

### DIFF
--- a/atchem.f90
+++ b/atchem.f90
@@ -626,7 +626,7 @@ PROGRAM ATCHEM
 
     call getConcForSpecInt( speciesConcs, SORNumber, concsOfSpeciesOfInterest )
     call outputSpeciesOutputRequired( t, concsOfSpeciesOfInterest )
-    call outputPhotolysisRates( j, t )
+    call outputPhotolysisRates( t )
 
     !OUTPUT INSTANTANEOUS RATES
     if ( mod( elapsed, irOutStepSize ) == 0 ) then

--- a/outputFunctions.f90
+++ b/outputFunctions.f90
@@ -39,11 +39,11 @@ contains
   end subroutine outputjfy
 
   !     ---------------------------------------------------------------
-  subroutine outputPhotolysisRates( j, t )
-    use photolysisRates, only : nrOfPhotoRates, ck
+  subroutine outputPhotolysisRates( t )
+    use photolysisRates, only : nrOfPhotoRates, ck, j
     implicit none
 
-    real(kind=DP), intent(in) :: j(*), t
+    real(kind=DP), intent(in) :: t
     integer(kind=NPI) :: i
 
     write (58, '(100 (1x, e12.5)) ') t, (j(ck(i)), i = 1, nrOfPhotoRates)


### PR DESCRIPTION
Use module data directly in outputPhotolysisRates() rather than passing around.