### PR TITLE
Modify outputFunctions.f90

### DIFF
--- a/atchem.f90
+++ b/atchem.f90
@@ -219,7 +219,7 @@ PROGRAM ATCHEM
   !   READ SPECIES NAMES AND NUMBERS
   write (*,*)
   write (*,*) 'Reading species names from mechanism.species...'
-  call readSpecies( numSpec, speciesNames, speciesNumber )
+  call readSpecies( speciesNames, speciesNumber )
   write (*,*) 'Finished reading species names.'
   write (*,*)
 

--- a/atchem.f90
+++ b/atchem.f90
@@ -67,7 +67,7 @@ PROGRAM ATCHEM
   !   DECLARATIONS FOR RATES OF PRODUCTION AND LOSS
   integer(kind=NPI), allocatable :: returnArray(:), tempSORNumber(:), SORNumber(:)
   integer(kind=NPI), allocatable :: prodIntSpecies(:,:), reacIntSpecies(:,:), prodArrayLen(:), lossArrayLen(:)
-  integer(kind=NPI) :: speciesOutputRequiredSize, SORNumberSize, prodIntNameSize, reacIntNameSize
+  integer(kind=NPI) :: SORNumberSize, prodIntNameSize, reacIntNameSize
   real(kind=DP), allocatable :: concsOfSpeciesOfInterest(:)
   character(len=maxSpecLength), allocatable :: prodIntName(:), reacIntName(:)
   character(len=maxSpecLength), allocatable :: speciesOutputRequired(:)
@@ -455,7 +455,7 @@ PROGRAM ATCHEM
   write (*,*)
 
   ! fill speciesOutputRequired with the names of species to output to concentration.output
-  call readSpeciesOutputRequired( speciesOutputRequired, speciesOutputRequiredSize )
+  call readSpeciesOutputRequired( speciesOutputRequired )
 
   ! fill SORNumber with the global numbering of the species found in speciesOutputRequired
   call matchNameToNumber( speciesNames, speciesOutputRequired, &

--- a/atchem.f90
+++ b/atchem.f90
@@ -233,7 +233,7 @@ PROGRAM ATCHEM
   write (*,*)
 
   !   READ IN PHOTOLYSIS RATE INFORMATION
-  call readPhotolysisConstants( ck, cl, cmm, cnn, photoRateNames, transmissionFactor )
+  call readPhotolysisConstants()
   write (*,*)
   !   Set default value for photonames array
   do i = 1, 200

--- a/atchem.f90
+++ b/atchem.f90
@@ -62,8 +62,7 @@ PROGRAM ATCHEM
 
   !   DECLARATIONS FOR SPECIES PARAMETERS
   real(kind=DP), allocatable :: initialConcentrations(:)
-  character(len=maxSpecLength), allocatable :: speciesNames(:), concSpeciesNames(:)
-  integer(kind=NPI), allocatable :: speciesNumber(:)
+  character(len=maxSpecLength), allocatable :: speciesNames(:), initConcSpeciesNames(:)
 
   !   DECLARATIONS FOR RATES OF PRODUCTION AND LOSS
   integer(kind=NPI), allocatable :: returnArray(:), tempSORNumber(:), SORNumber(:)
@@ -198,7 +197,7 @@ PROGRAM ATCHEM
   !    SET ARRAY SIZES = NO. OF SPECIES
   allocate (speciesConcs(numSpec), speciesNames(numSpec))
   speciesConcs(:) = 0
-  allocate (speciesNumber(numSpec), z(numSpec), initialConcentrations(numSpec))
+  allocate (z(numSpec), initialConcentrations(numSpec))
   allocate (returnArray(numSpec))
   allocate (tempSORNumber(numSpec))
   allocate (fy(numSpec, numSpec))
@@ -219,7 +218,7 @@ PROGRAM ATCHEM
   !   READ SPECIES NAMES AND NUMBERS
   write (*,*)
   write (*,*) 'Reading species names from mechanism.species...'
-  call readSpecies( speciesNames, speciesNumber )
+  call readSpecies( speciesNames )
   write (*,*) 'Finished reading species names.'
   write (*,*)
 
@@ -227,9 +226,9 @@ PROGRAM ATCHEM
   call setSpeciesList( speciesNames )
 
   !   SET INITIAL SPECIES CONCENTRATIONS
-  call readInitialConcentrations( concSpeciesNames, initialConcentrations )
-  call setConcentrations( speciesNames, concSpeciesNames, initialConcentrations, speciesConcs )
-  deallocate (concSpeciesNames, initialConcentrations)
+  call readInitialConcentrations( initConcSpeciesNames, initialConcentrations )
+  call setConcentrations( speciesNames, initConcSpeciesNames, initialConcentrations, speciesConcs )
+  deallocate (initConcSpeciesNames, initialConcentrations)
   write (*,*)
 
   !   READ IN PHOTOLYSIS RATE INFORMATION
@@ -703,7 +702,7 @@ PROGRAM ATCHEM
   !   deallocate CVODE internal data
 
   call FCVFREE()
-  deallocate (speciesConcs, speciesNames, speciesNumber, z)
+  deallocate (speciesConcs, speciesNames, z)
   deallocate (prodIntSpecies, returnArray, reacIntSpecies)
   deallocate (SORNumber, concsOfSpeciesOfInterest, prodIntName, reacIntName, speciesOutputRequired)
   deallocate (fy, ir)

--- a/atchem.f90
+++ b/atchem.f90
@@ -613,8 +613,8 @@ PROGRAM ATCHEM
 
     elapsed = int( t-modelStartTime )
     if ( mod( elapsed, ratesOutputStepSize ) == 0 ) then
-      call outputRates( prodIntSpecies, prodArrayLen, t, productionRates, 1, speciesNames )
-      call outputRates( reacIntSpecies, lossArrayLen, t, lossRates, 0, speciesNames )
+      call outputRates( prodIntSpecies, prodArrayLen, t, productionRates, 1 )
+      call outputRates( reacIntSpecies, lossArrayLen, t, lossRates, 0 )
     end if
 
     ! OUTPUT JACOBIAN MATRIX (OUTPUT FREQUENCY SET IN MODEL PARAMETERS)

--- a/atchem.f90
+++ b/atchem.f90
@@ -388,7 +388,7 @@ PROGRAM ATCHEM
   ratesOutputStepSize = modelParameters(8)
   ! Start time of model. Used to set t0, and to calculate the elapsed time.
   modelStartTime = modelParameters(9)
-  ! Frequency at which outputjfy is called below.
+  ! Frequency at which output_jfy is called below.
   jacobianOutputStepSize = modelParameters(10)
   ! Member variables of module SZACalcVars
   latitude = modelParameters(11)
@@ -621,7 +621,7 @@ PROGRAM ATCHEM
     write (*,*) 'time = ', time
     if ( mod( elapsed, jacobianOutputStepSize ) == 0 ) then
       call jfy( numSpec, numReac, speciesConcs, fy, t )
-      call outputjfy( fy, numSpec, t )
+      call output_jfy( fy, t )
     end if
 
     call getConcForSpecInt( speciesConcs, SORNumber, concsOfSpeciesOfInterest )

--- a/configFunctions.f90
+++ b/configFunctions.f90
@@ -143,6 +143,29 @@ contains
   end subroutine findReactionsWithProductOrReactant
 
 
+  subroutine getConcForSpecInt( masterConcList, speciesOfInterest, interestSpeciesConcList )
+    ! This subroutine outputs interestSpeciesConcList, the concentration of each species of interest,
+    ! in the same order as the species are in specInt
+    real(kind=DP), intent(in) :: masterConcList(:)
+    integer(kind=NPI), intent(in) :: speciesOfInterest(:)
+    real(kind=DP), intent(out) :: interestSpeciesConcList(:)
+    integer(kind=NPI) :: i, j
+    ! Set interestSpeciesConcList(j) to the value of the concentration pulled from masterConcList,
+    ! using the elements of specInt as a key
+    if ( size( interestSpeciesConcList ) /= size( speciesOfInterest ) ) then
+      stop 'size(interestSpeciesConcList) /= size(speciesOfInterest) in getConcForSpecInt'
+    end if
+    do i = 1, size( masterConcList )
+      do j = 1, size( speciesOfInterest )
+        if ( speciesOfInterest(j) == i ) then
+          interestSpeciesConcList(j) = masterConcList(i)
+        end if
+      end do
+    end do
+    return
+  end subroutine getConcForSpecInt
+
+
   subroutine setConcentrations( refSpeciesNames, concSpeciesNames, &
                                 inputConcentrations, outputConcentrations )
     ! For each input species in concSpeciesNames (size concCounter), and matching value in inputConcentrations (size inputConcentrationsSize),

--- a/dataStructures.f90
+++ b/dataStructures.f90
@@ -176,13 +176,13 @@ contains
     deallocate (speciesList)
   end subroutine deallocateSpeciesList
 
-  subroutine getSpeciesList( sl )
+  function getSpeciesList() result ( sl )
     character(len=maxSpecLength), allocatable :: sl(:)
     allocate (sl(numSpecies) )
     do i = 1, numSpecies
       sl(i) = speciesList(i)
     end do
-  end subroutine getSpeciesList
+  end function getSpeciesList
 
   subroutine setSpeciesList( sl )
     character(len=maxSpecLength) :: sl(:)

--- a/inputFunctions.f90
+++ b/inputFunctions.f90
@@ -299,14 +299,13 @@ contains
   end subroutine readPhotoRates
 
 
-  subroutine readSpeciesOutputRequired( r, i )
+  subroutine readSpeciesOutputRequired( r )
     use species, only : getNumberOfSpecies
     use directories, only : param_dir
     use storage, only : maxSpecLength, maxFilepathLength
     implicit none
 
     character(len=maxSpecLength), allocatable, intent(out) :: r(:)
-    integer(kind=NPI), intent(out) :: i
     character(len=maxFilepathLength) :: filename
     integer(kind=NPI) :: j, nsp, length
 
@@ -314,25 +313,25 @@ contains
     write (*,*) 'Reading concentration output from file...'
     length = count_lines_in_file( trim( filename ) )
     allocate (r(length) )
-    call read_in_single_column_string_file( trim( filename ), r, i )
+    call read_in_single_column_string_file( trim( filename ), r )
     write (*,*) 'Finished reading concentration output from file.'
 
     ! ERROR HANDLING
     nsp = getNumberOfSpecies()
-    if ( i > nsp ) then
+    if ( length > nsp ) then
       write (51,*) 'Error: Number of (number of species output is required for) > (number of species) '
-      write (51,*) "(number of species output is required for) = ", i
+      write (51,*) "(number of species output is required for) = ", length
       write (51,*) "(number of species) = ", nsp
       stop 2
     end if
 
-    write (*,*) 'Output required for concentration of', i, 'species:'
-    if ( i > 3 ) then
+    write (*,*) 'Output required for concentration of', length, 'species:'
+    if ( length > 3 ) then
       write (*,*) 1, r(1)
       write (*,*) '...'
-      write (*,*) i, r(i)
+      write (*,*) length, r(length)
     else
-      do j = 1, i
+      do j = 1, length
         write (*,*) j, r(j)
       end do
     end if
@@ -437,7 +436,7 @@ contains
   end subroutine readInitialConcentrations
 
 
-  subroutine readProductsOrReactantsOfInterest( filename, r, i )
+  subroutine readProductsOrReactantsOfInterest( filename, r, length )
     ! Read in contents of modelConfiguration/production/lossRatesOutput.config, which
     ! contains a list of the species we want to have outputted to mC/production/lossRates.output
     ! Output the contents in r, with i as the length of r.
@@ -446,9 +445,8 @@ contains
 
     character(len=*), intent(in) :: filename
     character(len=maxSpecLength), allocatable, intent(out) :: r(:)
-    integer(kind=NPI), intent(out) :: i
+    integer(kind=NPI), intent(out) :: length
     integer(kind=NPI) :: j
-    integer(kind=NPI) :: length
     logical :: file_exists
 
     inquire(file=trim( filename ), exist=file_exists)
@@ -457,14 +455,14 @@ contains
     else
       length = count_lines_in_file ( trim( filename ), .false. )
       allocate (r(length) )
-      call read_in_single_column_string_file( trim( filename ), r, i, .false. )
+      call read_in_single_column_string_file( trim( filename ), r, .false. )
     end if
-    if ( i > 3 ) then
+    if ( length > 3 ) then
       write (*,*) 1, ' ', r(1)
       write (*,*) '...'
-      write (*,*) i, ' ', r(i)
+      write (*,*) length, ' ', r(length)
     else
-      do j = 1, i
+      do j = 1, length
         write (*,*) j, ' ', r(j)
       end do
     end if
@@ -768,15 +766,15 @@ contains
     if ( counter == -1 ) counter = 0
   end function count_lines_in_file
 
-  subroutine read_in_single_column_string_file( filename, output_vector, i, skip_first_line_in )
+  subroutine read_in_single_column_string_file( filename, output_vector, skip_first_line_in )
     use storage, only : maxSpecLength
 
     character(len=*), intent(in) :: filename
     character(len=*), intent(out) :: output_vector(:)
-    integer(kind=NPI), intent(out) :: i
     logical, intent(in), optional :: skip_first_line_in
     logical :: skip_first_line
     character(len=maxSpecLength) :: c
+    integer(kind=NPI) :: i
     integer(kind=IntErr) :: ierr
     ! Set default to not skip first line
     if ( .not. present(skip_first_line_in)) then

--- a/inputFunctions.f90
+++ b/inputFunctions.f90
@@ -362,22 +362,18 @@ contains
   end subroutine readNumberOfSpeciesAndReactions
 
 
-  subroutine readSpecies( speciesName, speciesNumber )
+  subroutine readSpecies( speciesName )
     use storage, only : maxSpecLength
     implicit none
 
-    integer(kind=NPI) :: j
     character(len=maxSpecLength), intent(out) :: speciesName(:)
-    integer(kind=NPI), intent(out) :: speciesNumber(:)
+    integer(kind=NPI) :: j, dummy
 
     ! Read in species number and name from mC/mechanism.species to speciesName
-    ! and speciesNumber. Also set each element of y to 0.
-    if ( size( speciesName ) /= size( speciesNumber ) ) then
-      stop "size( speciesName ) /= size( speciesNumber ) in readSpecies()."
-    end if
+    ! and sdummy (to be thrown).
     open (10, file='modelConfiguration/mechanism.species') ! input file
     do j = 1, size ( speciesName )
-      read (10,*) speciesNumber(j), speciesName(j)
+      read (10,*) dummy, speciesName(j)
     end do
     close (10, status='keep')
 
@@ -396,9 +392,9 @@ contains
     implicit none
 
     character(len=maxSpecLength), allocatable, intent(out) :: concSpeciesNames(:)
+    real(kind=DP), allocatable, intent(out) :: concentration(:)
     character(len=maxSpecLength) :: k
     character(len=maxFilepathLength) :: file
-    real(kind=DP), allocatable, intent(out) :: concentration(:)
     real(kind=DP) :: l
     integer(kind=NPI) :: numLines, i, nsp
     integer(kind=IntErr) :: ierr

--- a/inputFunctions.f90
+++ b/inputFunctions.f90
@@ -362,19 +362,21 @@ contains
   end subroutine readNumberOfSpeciesAndReactions
 
 
-  subroutine readSpecies( neq, speciesName, speciesNumber )
+  subroutine readSpecies( speciesName, speciesNumber )
     use storage, only : maxSpecLength
     implicit none
 
-    integer(kind=NPI), intent(in) :: neq
     integer(kind=NPI) :: j
     character(len=maxSpecLength), intent(out) :: speciesName(:)
     integer(kind=NPI), intent(out) :: speciesNumber(:)
 
     ! Read in species number and name from mC/mechanism.species to speciesName
     ! and speciesNumber. Also set each element of y to 0.
+    if ( size( speciesName ) /= size( speciesNumber ) ) then
+      stop "size( speciesName ) /= size( speciesNumber ) in readSpecies()."
+    end if
     open (10, file='modelConfiguration/mechanism.species') ! input file
-    do j = 1, neq
+    do j = 1, size ( speciesName )
       read (10,*) speciesNumber(j), speciesName(j)
     end do
     close (10, status='keep')

--- a/inputFunctions.f90
+++ b/inputFunctions.f90
@@ -501,7 +501,7 @@ contains
     character(len=maxSpecLength) :: name
     character(len=maxFilepathLength+maxSpecLength) :: fileLocation
 
-    call getSpeciesList( speciesName )
+    speciesName =  getSpeciesList()
 
     ! READ IN SPECIES TO BE CONSTRAINED
     write (*,*) 'Counting the species to be constrained (in file constrainedSpecies.config)...'

--- a/outputFunctions.f90
+++ b/outputFunctions.f90
@@ -8,6 +8,8 @@ contains
     real(kind=DP), intent(in) :: y(*)
 
     ro2 = 0.00e+00
+
+    return
   end subroutine ro2Sum
 
 
@@ -39,6 +41,8 @@ contains
       write (55, '(100 (1x, e12.5)) ') t, (fy(i, j), j = 1, size( fy, 1))
     end do
     write (55,*) '---------------'
+
+    return
   end subroutine output_jfy
 
 
@@ -50,6 +54,7 @@ contains
     integer(kind=NPI) :: i
 
     write (58, '(100 (1x, e12.5)) ') t, (j(ck(i)), i = 1, nrOfPhotoRates)
+
     return
   end subroutine outputPhotolysisRates
 
@@ -150,6 +155,7 @@ contains
         end if
       end do
     end do
+
     return
   end subroutine outputRates
 
@@ -177,7 +183,6 @@ contains
       write (10,*) ir(i)
     end do
     close (10, status='keep')
-
 
     return
   end subroutine outputInstantaneousRates

--- a/outputFunctions.f90
+++ b/outputFunctions.f90
@@ -118,8 +118,9 @@ contains
   end function getReaction
 
 
-  subroutine outputRates( r, arrayLen, t, p, flag, speciesNames )
+  subroutine outputRates( r, arrayLen, t, p, flag )
     use reactionStructure
+    use species, only : getSpeciesList
     use storage, only : maxSpecLength, maxReactionStringLength
     use, intrinsic :: iso_fortran_env, only : stderr => error_unit
     implicit none
@@ -127,13 +128,16 @@ contains
     integer(kind=NPI), intent(in) :: r(:,:), arrayLen(:)
     real(kind=DP), intent(in) :: t, p(:)
     integer, intent(in) :: flag
-    character(len=maxSpecLength), intent(in) :: speciesNames(:)
+    character(len=maxSpecLength), allocatable :: speciesNames(:)
     integer(kind=NPI) :: i, j
     character(len=maxReactionStringLength) :: reaction
 
     if ( size( r, 1 ) /= size( arrayLen ) ) then
       stop "size( r, 1 ) /= size( arrayLen ) in outputRates()."
     end if
+
+    speciesNames = getSpeciesList()
+
     do i = 1, size( arrayLen )
       if ( arrayLen(i) > size( r, 2 ) ) then
         write (stderr,*) "arrayLen(i) > size( r, 2 ) in outputRates(). i = ", i

--- a/outputFunctions.f90
+++ b/outputFunctions.f90
@@ -61,7 +61,7 @@ contains
 
   pure function getReaction( speciesNames, reactionNumber ) result ( reaction )
     ! Given a list speciesNames, and an integer reactionNumber, return reaction,
-    ! a string containing
+    ! a string containing the string representing that reaction.
     use reactionStructure
     use storage, only : maxSpecLength, maxReactionStringLength
     implicit none

--- a/outputFunctions.f90
+++ b/outputFunctions.f90
@@ -24,19 +24,21 @@ contains
   end subroutine outputEnvVar
 
   !--------------------------------------------------------------------
-  subroutine outputjfy( fy, nsp, t )
+  subroutine output_jfy( fy, t )
     implicit none
 
-    integer(kind=NPI), intent(in) :: nsp
+    real(kind=DP), intent(in) :: fy(:,:), t
     integer(kind=NPI) :: i, j
-    real(kind=DP), intent(in) :: fy(nsp, nsp), t
 
+    if ( size( fy, 1 ) /= size( fy, 2 ) ) then
+      stop "size( fy, 1 ) /= size( fy, 2 ) in output_jfy()."
+    end if
     ! Loop over all elements of fy, and print to jacobian.output, prefixed by t
-    do i = 1, nsp
-      write (55, '(100 (1x, e12.5)) ') t, (fy(i, j), j = 1, nsp)
+    do i = 1, size( fy, 1)
+      write (55, '(100 (1x, e12.5)) ') t, (fy(i, j), j = 1, size( fy, 1))
     end do
     write (55,*) '---------------'
-  end subroutine outputjfy
+  end subroutine output_jfy
 
   !     ---------------------------------------------------------------
   subroutine outputPhotolysisRates( t )

--- a/outputFunctions.f90
+++ b/outputFunctions.f90
@@ -23,7 +23,7 @@ contains
     return
   end subroutine outputEnvVar
 
-  !--------------------------------------------------------------------
+
   subroutine output_jfy( fy, t )
     implicit none
 
@@ -40,7 +40,7 @@ contains
     write (55,*) '---------------'
   end subroutine output_jfy
 
-  !     ---------------------------------------------------------------
+
   subroutine outputPhotolysisRates( t )
     use photolysisRates, only : nrOfPhotoRates, ck, j
     implicit none
@@ -52,30 +52,7 @@ contains
     return
   end subroutine outputPhotolysisRates
 
-  !     ---------------------------------------------------------------
-  subroutine getConcForSpecInt( masterConcList, speciesOfInterest, interestSpeciesConcList )
-    ! This subroutine outputs interestSpeciesConcList, the concentration of each species of interest,
-    ! in the same order as the species are in specInt
-    real(kind=DP), intent(in) :: masterConcList(:)
-    integer(kind=NPI), intent(in) :: speciesOfInterest(:)
-    real(kind=DP), intent(out) :: interestSpeciesConcList(:)
-    integer(kind=NPI) :: i, j
-    ! Set interestSpeciesConcList(j) to the value of the concentration pulled from masterConcList,
-    ! using the elements of specInt as a key
-    if ( size( interestSpeciesConcList ) /= size( speciesOfInterest ) ) then
-      stop 'size(interestSpeciesConcList) /= size(speciesOfInterest) in getConcForSpecInt'
-    end if
-    do i = 1, size( masterConcList )
-      do j = 1, size( speciesOfInterest )
-        if ( speciesOfInterest(j) == i ) then
-          interestSpeciesConcList(j) = masterConcList(i)
-        end if
-      end do
-    end do
-    return
-  end subroutine getConcForSpecInt
 
-  !     ---------------------------------------------------------------
   subroutine getReaction( speciesNames, reactionNumber, reaction )
     ! Given a list speciesNames, and an integer reactionNumber, return reaction,
     ! a string containing
@@ -135,6 +112,7 @@ contains
     return
   end subroutine getReaction
 
+
   subroutine outputRates( r, arrayLen, t, p, flag, speciesNames )
     use reactionStructure
     use storage, only : maxSpecLength, maxReactionStringLength
@@ -175,6 +153,7 @@ contains
     return
   end subroutine outputRates
 
+
   subroutine outputInstantaneousRates( time, numReac )
     use reactionStructure
     use directories, only : instantaneousRates_dir
@@ -202,6 +181,7 @@ contains
 
     return
   end subroutine outputInstantaneousRates
+
 
   subroutine outputSpeciesOutputRequired( t, arrayOfConcs )
     ! Print each element of arrayOfConcs, with size arrayOfConcsSize.

--- a/outputFunctions.f90
+++ b/outputFunctions.f90
@@ -10,6 +10,7 @@ contains
     ro2 = 0.00e+00
   end subroutine ro2Sum
 
+
   subroutine outputEnvVar( t )
     use envVars
     implicit none

--- a/outputFunctions.f90
+++ b/outputFunctions.f90
@@ -53,7 +53,7 @@ contains
   end subroutine outputPhotolysisRates
 
 
-  subroutine getReaction( speciesNames, reactionNumber, reaction )
+  pure function getReaction( speciesNames, reactionNumber ) result ( reaction )
     ! Given a list speciesNames, and an integer reactionNumber, return reaction,
     ! a string containing
     use reactionStructure
@@ -64,8 +64,7 @@ contains
     character(len=maxSpecLength), intent(in) :: speciesNames(*)
     integer(kind=NPI) :: i, numReactants, numProducts
     integer(kind=NPI), intent(in) :: reactionNumber
-    character(len=maxReactionStringLength) :: reactantStr, productStr
-    character(len=maxReactionStringLength), intent(out) :: reaction
+    character(len=maxReactionStringLength) :: reactantStr, productStr, reaction
 
     ! Loop over reactants, and copy the reactant name for any reactant used in
     ! reaction reactionNumber. use numReactants as a counter of the number of reactants.
@@ -110,7 +109,7 @@ contains
     reaction = trim( reactantStr ) // trim( productStr )
 
     return
-  end subroutine getReaction
+  end function getReaction
 
 
   subroutine outputRates( r, arrayLen, t, p, flag, speciesNames )
@@ -137,7 +136,7 @@ contains
       do j = 2, arrayLen(i)
         if ( r(i, j) /= -1 ) then
 
-          call getReaction( speciesNames, r(i, j), reaction )
+          reaction = getReaction( speciesNames, r(i, j) )
           ! Flag = 0 for reaction, 1 for loss
           if ( flag == 0 ) then
             write (56,*) t, ' ', r(i, 1), ' ', speciesNames(r(i, 1)), ' ', r(i, j), ' ', p(r(i, j)), ' ', trim( reaction )


### PR DESCRIPTION
Rename `outputjfy()` to `output_jfy()`. Remove`nsp` argument from it.

Move `getConcForSpecInt()` to configFunctions.f90.

Change `getSpeciesList()` to a function, and use in `outputRates()` rather than passing in `speciesNames` as an argument.