### PR TITLE
Reading of photolysis rates and constants

### DIFF
--- a/atchem.f90
+++ b/atchem.f90
@@ -10,7 +10,7 @@ PROGRAM ATCHEM
   use constraints
   use interpolationMethod
   use reactionStructure
-  use photolysisRates
+  use photolysisRates_mod
   use chemicalConstraints
   use zenithData
   use zenithData1

--- a/constraintFunctions.f90
+++ b/constraintFunctions.f90
@@ -6,7 +6,7 @@ contains
   subroutine calcJFac( t, jfac )
     use types_mod
     use zenithData1
-    use photolysisRates
+    use photolysisRates_mod
     use constraints
     use interpolationFunctions_mod, only : getConstrainedQuantAtT
     use interpolationMethod, only : getConditionsInterpMethod
@@ -295,7 +295,7 @@ contains
   subroutine test_jfac()
     ! check jfac data consistency
     use types_mod
-    use photolysisRates
+    use photolysisRates_mod
     use envVars
     implicit none
     integer(kind=NPI) :: envVarNum

--- a/dataStructures.f90
+++ b/dataStructures.f90
@@ -256,7 +256,7 @@ end module reactionStructure
 !    ********************************************************************************************************
 !    PHOTOLYSIS RATES METHOD MODULE
 !    ********************************************************************************************************
-module photolysisRates
+module photolysisRates_mod
   use types_mod
   use storage, only : maxPhotoRateNameLength
   implicit none
@@ -295,7 +295,7 @@ contains
 
     allocate (j(size_of_j))
   end subroutine allocate_photolysis_j
-end module photolysisRates
+end module photolysisRates_mod
 
 !    ********************************************************************************************************
 !    CHEMICAL CONSTRAINTS MODULE

--- a/dataStructures.f90
+++ b/dataStructures.f90
@@ -262,18 +262,39 @@ module photolysisRates
   implicit none
   save
 
-  integer, parameter :: maxNrOfPhotoRates = 200, maxNrOfConPhotoRates = 100
-  integer(kind=NPI) :: ck(maxNrOfPhotoRates), numConPhotoRates, constrainedPhotoRatesNumbers(maxNrOfConPhotoRates)
+  integer, parameter :: maxNrOfConPhotoRates = 100
+  integer(kind=NPI) :: numConPhotoRates, constrainedPhotoRatesNumbers(maxNrOfConPhotoRates)
   integer(kind=NPI) :: jfacSpeciesLine ! number of line in photolysis rates file corresponding to Jfac species
   integer(kind=NPI) :: nrOfPhotoRates
+  integer(kind=NPI), allocatable :: ck(:)
   logical :: usePhotolysisConstants
-  real(kind=DP) :: cl(maxNrOfPhotoRates), cmm(maxNrOfPhotoRates), cnn(maxNrOfPhotoRates)
-  real(kind=DP) :: j(maxNrOfPhotoRates), transmissionFactor(maxNrOfPhotoRates)
-  character(len=maxPhotoRateNameLength) :: photoRateNames(maxNrOfPhotoRates)
+  real(kind=DP), allocatable :: cl(:), cmm(:), cnn(:), transmissionFactor(:)
+  real(kind=DP), allocatable :: j(:)
+  character(len=maxPhotoRateNameLength), allocatable :: photoRateNames(:)
   character(len=maxPhotoRateNameLength) :: constrainedPhotoRates(maxNrOfConPhotoRates), jFacSpecies
   real(kind=DP), allocatable :: photoX(:,:), photoY(:,:), photoY2(:,:)
   integer(kind=NPI), allocatable :: photoNumberOfPoints(:)
+  integer(kind=NPI) :: size_of_j
 
+contains
+  subroutine allocate_photolysis_constants_variables()
+    implicit none
+
+    allocate (ck(nrOfPhotoRates), cl(nrOfPhotoRates), photoRateNames(nrOfPhotoRates))
+  end subroutine allocate_photolysis_constants_variables
+
+  subroutine allocate_photolysis_rates_variables()
+    implicit none
+
+    allocate (ck(nrOfPhotoRates), cl(nrOfPhotoRates), cmm(nrOfPhotoRates))
+    allocate (cnn(nrOfPhotoRates), photoRateNames(nrOfPhotoRates), transmissionFactor(nrOfPhotoRates))
+  end subroutine allocate_photolysis_rates_variables
+
+  subroutine allocate_photolysis_j()
+    implicit none
+
+    allocate (j(size_of_j))
+  end subroutine allocate_photolysis_j
 end module photolysisRates
 
 !    ********************************************************************************************************

--- a/inputFunctions.f90
+++ b/inputFunctions.f90
@@ -186,8 +186,8 @@ contains
     ! If modelConfiguration/photolysisConstants.config exists, then read in
     ! 3 values to fill ck, cl and str.
     ! Otherwise, call ReadPhotolysisRates to fill ck, cl, cmm, cnn, str and tf.
-    use photolysisRates, only : usePhotolysisConstants, nrOfPhotoRates, &
-                                ck, cl, photoRateNames, allocate_photolysis_rates_variables, size_of_j, allocate_photolysis_j
+    use photolysisRates_mod, only : usePhotolysisConstants, nrOfPhotoRates, ck, cl, photoRateNames, &
+                                    allocate_photolysis_rates_variables, size_of_j, allocate_photolysis_j
     use directories, only : param_dir
     use storage, only : maxFilepathLength
     implicit none
@@ -250,8 +250,8 @@ contains
     ! This is called from readPhotolysisConstants if modelConfiguration/photolysisConstants.config
     ! doesn't exist. It reads ck, cl, cmm, cnn, str, and tf from
     ! modelConfiguration/photolysisRates.config.
-    use photolysisRates, only : nrOfPhotoRates, ck, cl, cmm, cnn, photoRateNames, transmissionFactor, &
-                                allocate_photolysis_rates_variables, size_of_j, allocate_photolysis_j
+    use photolysisRates_mod, only : nrOfPhotoRates, ck, cl, cmm, cnn, photoRateNames, transmissionFactor, &
+                                    allocate_photolysis_rates_variables, size_of_j, allocate_photolysis_j
     use directories, only : param_dir
     use storage, only : maxFilepathLength
     use, intrinsic :: iso_fortran_env, only : stderr => error_unit
@@ -305,7 +305,7 @@ contains
     ! Read modelConfiguration/JFacSpecies.config, and store this in jFacSpecies.
     ! Test this against known species, and if it is known then set jfacSpeciesLine
     ! to that line number in photoRateNames
-    use photolysisRates
+    use photolysisRates_mod
     use directories, only : param_dir
     implicit none
 
@@ -531,7 +531,7 @@ contains
 
 
   subroutine readPhotoRates()
-    use photolysisRates, only : photoX, photoY, photoY2, numConPhotoRates, maxNrOfConPhotoRates, photoNumberOfPoints, &
+    use photolysisRates_mod, only : photoX, photoY, photoY2, numConPhotoRates, maxNrOfConPhotoRates, photoNumberOfPoints, &
                                 constrainedPhotoRates, nrOfPhotoRates, photoRateNames, constrainedPhotoRatesNumbers, ck
     use directories, only : param_dir, env_constraints_dir
     use storage, only : maxPhotoRateNameLength, maxFilepathLength

--- a/mechanism-rates.f90
+++ b/mechanism-rates.f90
@@ -5,7 +5,7 @@ contains
     use, intrinsic :: iso_fortran_env, only : stderr => error_unit
     use types_mod
     use storage, only : maxEnvVarNameLength
-    use photolysisRates
+    use photolysisRates_mod
     use zenithData1, only : cosX, secX
     use constraints
     use envVars, only : ro2, envVarNames, currentEnvVarValues

--- a/outputFunctions.f90
+++ b/outputFunctions.f90
@@ -137,7 +137,7 @@ contains
 
 
   subroutine outputPhotolysisRates( t, photoRateNamesForHeader )
-    use photolysisRates, only : nrOfPhotoRates, ck, j
+    use photolysisRates_mod, only : nrOfPhotoRates, ck, j
     implicit none
 
     real(kind=DP), intent(in) :: t


### PR DESCRIPTION
Only allocate `cl`, `cmm`, `cnn`, `transmissionFactor`, `photoRateNames` (all members of photolysisRates module) to the needed size. Also allocate `j` (another member) to the correct size, but this is based on the max value of `ck`, not the size of the input file. Tidy up reading of these files too.