### PR TITLE
Tidy reactionStructure module

### DIFF
--- a/atchem.f90
+++ b/atchem.f90
@@ -208,16 +208,12 @@ PROGRAM ATCHEM
   allocate (lossRates(numReac), productionRates(numReac), ir(numReac))
 
   !   GET SIZES OF REACTANTS AND PRODUCT INPUT FILES
-  call getReactantAndProductListSizes()
+  call getAndAllocateReactantAndProductListSizes()
 
-  allocate (clhs(3, lhs_size), crhs(2, rhs_size), ccoeff(rhs_size))
 
   !   READ IN CHEMICAL REACTIONS
-  call readReactions( clhs, crhs, ccoeff )
+  call readReactions( clhs, clcoeff, crhs, crcoeff )
   neq = numSpec
-
-  write (*, '(A, I0)') ' Size of lhs = ', lhs_size
-  write (*, '(A, I0)') ' Size of rhs = ', rhs_size
 
   !   READ SPECIES NAMES AND NUMBERS
   write (*,*)
@@ -254,7 +250,7 @@ PROGRAM ATCHEM
   call readProductsOrReactantsOfInterest( trim( param_dir ) // '/productionRatesOutput.config', prodIntName, numProdIntSpecies )
   write (*,*) 'Finished reading products of interest.'
 
-  allocate (prodIntSpecies(numProdIntSpecies, rhs_size))
+  allocate (prodIntSpecies(numProdIntSpecies, size( crhs, 2 )))
   allocate (prodIntSpeciesLengths(numProdIntSpecies))
   ! Fill prodIntSpecies(:,1) with a list of the numbers of the interesting product species, with numbers from their ordering in speciesNames
   call matchNameToNumber( speciesNames, prodIntName, prodIntSpecies(:, 1) )
@@ -271,7 +267,7 @@ PROGRAM ATCHEM
   call readProductsOrReactantsOfInterest( trim( param_dir ) // '/lossRatesOutput.config', reacIntName, numReacIntSpecies )
   write (*,*) 'Finished reading reactants of interest.'
 
-  allocate (reacIntSpecies(numReacIntSpecies, lhs_size))
+  allocate (reacIntSpecies(numReacIntSpecies, size( clhs, 2 )))
   allocate (reacIntSpeciesLengths(numReacIntSpecies))
   ! Fill reacIntSpecies(:,1) with a list of the numbers of the interesting reaction species, with numbers from their ordering in speciesNames
   call matchNameToNumber( speciesNames, reacIntName, reacIntSpecies(:, 1) )
@@ -678,7 +674,7 @@ PROGRAM ATCHEM
   deallocate (SORNumber, concsOfSpeciesOfInterest, prodIntName, reacIntName, speciesOutputRequired)
   deallocate (fy, ir)
   deallocate (lossRates, productionRates)
-  deallocate (clhs, crhs, ccoeff)
+  deallocate (clhs, clcoeff, crhs, crcoeff)
   deallocate (prodIntSpeciesLengths)
   deallocate (reacIntSpeciesLengths)
   !   deallocate data allocated before in input functions(inputFunctions.f)
@@ -800,7 +796,7 @@ subroutine FCVFUN( t, y, ydot, ipar, rpar, ier )
 
   call addConstrainedSpeciesToProbSpec( y, constrainedConcs, constrainedSpecies, z )
 
-  call resid( numReac, t, z, dy, clhs, crhs, ccoeff )
+  call resid( numReac, t, z, dy, clhs, clcoeff, crhs, crcoeff )
 
   call removeConstrainedSpeciesFromProbSpec( dy, constrainedSpecies, ydot )
 

--- a/dataStructures.f90
+++ b/dataStructures.f90
@@ -283,8 +283,7 @@ module reactionStructure
   save
 
   integer(kind=NPI), allocatable :: clhs(:,:), crhs(:,:)
-  integer(kind=NPI) :: lhs_size, rhs_size
-  real(kind=DP), allocatable :: ccoeff(:)
+  real(kind=DP), allocatable :: clcoeff(:), crcoeff(:)
 
 end module reactionStructure
 

--- a/outputFunctions.f90
+++ b/outputFunctions.f90
@@ -171,7 +171,7 @@ contains
     ! reaction reactionNumber. use numReactants as a counter of the number of reactants.
     ! String these together with '+', and append a '='
     numReactants = 0
-    do i = 1, lhs_size
+    do i = 1, size( clhs, 2 )
       if ( clhs(1, i) == reactionNumber ) then
         numReactants = numReactants + 1
         reactants(numReactants) = speciesNames(clhs(2, i))
@@ -192,7 +192,7 @@ contains
     ! String these together with '+', and append this to reactantStr. Save the
     ! result in reaction, which is returned
     numProducts = 0
-    do i = 1, rhs_size
+    do i = 1, size( crhs, 2 )
       if ( crhs(1, i) == reactionNumber ) then
         numProducts = numProducts + 1
         products(numProducts) = speciesNames(crhs(2, i))

--- a/travis/tests/full.out.cmp
+++ b/travis/tests/full.out.cmp
@@ -5,11 +5,12 @@
  Number of Species   = 5832
  Number of Reactions = 17224
 
+ Size of lhs = 27018
+ Size of rhs = 30225
+
  Reading reactants (lhs) from mechanism.reac...
  Reading products (rhs) from mechanism.prod...
  Finished reading lhs and rhs data.
- Size of lhs = 27018
- Size of rhs = 30225
 
  Reading species names from mechanism.species...
  Finished reading species names.
@@ -153,5 +154,5 @@
  No. nonlinear convergence failures = 0
  No. error test failures = 0
 
- Runtime = 12
+ Runtime = 22
  Deallocating memory.

--- a/travis/tests/short.out.cmp
+++ b/travis/tests/short.out.cmp
@@ -5,11 +5,12 @@
  Number of Species   = 104
  Number of Reactions = 324
 
+ Size of lhs = 510
+ Size of rhs = 558
+
  Reading reactants (lhs) from mechanism.reac...
  Reading products (rhs) from mechanism.prod...
  Finished reading lhs and rhs data.
- Size of lhs = 510
- Size of rhs = 558
 
  Reading species names from mechanism.species...
  Finished reading species names.

--- a/travis/tests/short_extended.out.cmp
+++ b/travis/tests/short_extended.out.cmp
@@ -5,11 +5,12 @@
  Number of Species   = 104
  Number of Reactions = 324
 
+ Size of lhs = 510
+ Size of rhs = 558
+
  Reading reactants (lhs) from mechanism.reac...
  Reading products (rhs) from mechanism.prod...
  Finished reading lhs and rhs data.
- Size of lhs = 510
- Size of rhs = 558
 
  Reading species names from mechanism.species...
  Finished reading species names.

--- a/travis/tests/single_reac_of_interest.out.cmp
+++ b/travis/tests/single_reac_of_interest.out.cmp
@@ -5,11 +5,12 @@
  Number of Species   = 104
  Number of Reactions = 324
 
+ Size of lhs = 510
+ Size of rhs = 558
+
  Reading reactants (lhs) from mechanism.reac...
  Reading products (rhs) from mechanism.prod...
  Finished reading lhs and rhs data.
- Size of lhs = 510
- Size of rhs = 558
 
  Reading species names from mechanism.species...
  Finished reading species names.

--- a/travis/tests/spec_no_env_yes1.out.cmp
+++ b/travis/tests/spec_no_env_yes1.out.cmp
@@ -5,11 +5,12 @@
  Number of Species   = 29
  Number of Reactions = 71
 
+ Size of lhs = 114
+ Size of rhs = 100
+
  Reading reactants (lhs) from mechanism.reac...
  Reading products (rhs) from mechanism.prod...
  Finished reading lhs and rhs data.
- Size of lhs = 114
- Size of rhs = 100
 
  Reading species names from mechanism.species...
  Finished reading species names.

--- a/travis/tests/spec_yes_env_no.out.cmp
+++ b/travis/tests/spec_yes_env_no.out.cmp
@@ -5,11 +5,12 @@
  Number of Species   = 29
  Number of Reactions = 71
 
+ Size of lhs = 114
+ Size of rhs = 100
+
  Reading reactants (lhs) from mechanism.reac...
  Reading products (rhs) from mechanism.prod...
  Finished reading lhs and rhs data.
- Size of lhs = 114
- Size of rhs = 100
 
  Reading species names from mechanism.species...
  Finished reading species names.

--- a/travis/tests/spec_yes_env_yes.out.cmp
+++ b/travis/tests/spec_yes_env_yes.out.cmp
@@ -5,11 +5,12 @@
  Number of Species   = 29
  Number of Reactions = 71
 
+ Size of lhs = 114
+ Size of rhs = 100
+
  Reading reactants (lhs) from mechanism.reac...
  Reading products (rhs) from mechanism.prod...
  Finished reading lhs and rhs data.
- Size of lhs = 114
- Size of rhs = 100
 
  Reading species names from mechanism.species...
  Finished reading species names.

--- a/travis/tests/spec_yes_plus_fixed_env_no.out.cmp
+++ b/travis/tests/spec_yes_plus_fixed_env_no.out.cmp
@@ -5,11 +5,12 @@
  Number of Species   = 29
  Number of Reactions = 71
 
+ Size of lhs = 114
+ Size of rhs = 100
+
  Reading reactants (lhs) from mechanism.reac...
  Reading products (rhs) from mechanism.prod...
  Finished reading lhs and rhs data.
- Size of lhs = 114
- Size of rhs = 100
 
  Reading species names from mechanism.species...
  Finished reading species names.


### PR DESCRIPTION
Split clhs into lhs clhs and clcoeff. Rename ccoeff to crcoeff. Move allocation of clhs, crhs, clcoeff and crcoeff into getAndAllocateReactantAndProductListSizes(), remove lhs_size and rhs_size from reactionStructure module.