### PR TITLE
Interpolation methods

### DIFF
--- a/atchem.f90
+++ b/atchem.f90
@@ -84,9 +84,9 @@ PROGRAM ATCHEM
   integer :: irOutStepSize
 
   integer(kind=QI) :: cmd_arg_count
-  !    MISC
+
   character(len=30) :: solverTypeName(3)
-  character(len=20) :: interpolationMethodName(4)
+  character(len=20) :: interpolationMethodName(2)
 
 
   interface
@@ -135,10 +135,8 @@ PROGRAM ATCHEM
   solverTypeName(1) = 'SPGMR'
   solverTypeName(2) = 'SPGMR + Banded Preconditioner'
   solverTypeName(3) = 'Dense'
-  interpolationMethodName(1) = 'cubic spline'
-  interpolationMethodName(2) = 'cubic spline ln'
-  interpolationMethodName(3) = 'piecewise constant'
-  interpolationMethodName(4) = 'piecewise linear'
+  interpolationMethodName(1) = 'piecewise constant'
+  interpolationMethodName(2) = 'piecewise linear'
   !    ********************************************************************************************************
   !    MODEL SETUP AND CONFIGURATION
   !    ********************************************************************************************************
@@ -356,10 +354,8 @@ PROGRAM ATCHEM
   ! the private member of MODULE interpolationMethod.
   ! getSpeciesInterpMethod() is called by getConstrainedQuantAtT.
   ! Values:
-  ! 1: Cubic spline interpolation
-  ! 2: Cubic spline interpolation (log) TODO: this just outputs the exponential of the value. Is this right?
-  ! 3: Piecewise constant
-  ! 4: Piecewise linear
+  ! 1: Piecewise constant
+  ! 2: Piecewise linear
   ! otherwise: error
   speciesInterpolationMethod = modelParameters(3)
   call setSpeciesInterpMethod( speciesInterpolationMethod )

--- a/interpolationFunctions.f90
+++ b/interpolationFunctions.f90
@@ -16,7 +16,7 @@ contains
     real(kind=DP), intent(out) :: concAtT
     real(kind=DP) :: xBefore, xAfter, yBefore, yAfter, m, c
     integer(kind=NPI) :: i, indexBefore, indexAfter
-    logical :: fac_int_found, lin_int_suc
+    logical :: constant_int_success, linear_int_success
 
     ! Sanity checks on sizes of x, y and y2.
     if ( size( x, 1 ) /= size( y, 1 ) ) then
@@ -45,15 +45,15 @@ contains
         concAtT = exp( concAtT )
         ! PIECEWISE CONSTANT INTERPOLATION
       case ( 3 )
-        fac_int_found = .false.
+        constant_int_success = .false.
         do i = 1, dataNumberOfPoints
           if ( (t >= x(ind, i) ) .and. ( t < x(ind, i+1) ) ) then
             concAtT = y(ind, i)
-            fac_int_found = .true.
+            constant_int_success = .true.
             exit
           end if
         end do
-        if ( fac_int_found .eqv. .false. ) then
+        if ( constant_int_success .eqv. .false. ) then
           write (*, '(A)') ' error in piecewise constant interpolation'
           write (*,*) t, dataNumberOfPoints, concAtT
           concAtT = y(ind, dataNumberOfPoints)
@@ -61,15 +61,15 @@ contains
         ! PIECEWISE LINEAR INTERPOLATION
       case ( 4 )
         ! FIND THE INDICES OF THE ENCLOSING DATA POINTS
-        lin_int_suc = .false.
+        linear_int_success = .false.
         do i = 1, dataNumberOfPoints
           if ( ( t >= x(ind, i) ) .and. ( t < x(ind, i+1) ) ) then
             indexBefore = i
             indexAfter = i + 1
-            lin_int_suc = .true.
+            linear_int_success = .true.
           end if
         end do
-        if ( lin_int_suc .eqv. .false. ) then
+        if ( linear_int_success .eqv. .false. ) then
           concAtT = y(ind, dataNumberOfPoints)
           write (*, '(A)') ' Failed to lin int'
         else

--- a/interpolationFunctions.f90
+++ b/interpolationFunctions.f90
@@ -15,7 +15,7 @@ contains
     integer(kind=NPI), intent(in) :: ind
     real(kind=DP), intent(out) :: concAtT
     real(kind=DP) :: xBefore, xAfter, yBefore, yAfter, m, c
-    integer(kind=NPI) :: i, indexBefore, indexAfter
+    integer(kind=NPI) :: i, indexBefore
     logical :: constant_int_success, linear_int_success
 
     ! Sanity checks on sizes of x, y and y2.
@@ -33,7 +33,7 @@ contains
     end if
 
     select case ( interpMethod )
-      ! PIECEWISE CONSTANT INTERPOLATION
+      ! left-sided piecewise constant interpolation
       case ( 1 )
         constant_int_success = .false.
         do i = 1, dataNumberOfPoints
@@ -48,27 +48,27 @@ contains
           write (*,*) t, dataNumberOfPoints, concAtT
           concAtT = y(ind, dataNumberOfPoints)
         end if
-        ! PIECEWISE LINEAR INTERPOLATION
+        ! piecewise linear interpolation
       case ( 2 )
-        ! FIND THE INDICES OF THE ENCLOSING DATA POINTS
+        ! Find the interval in which t sits
         linear_int_success = .false.
         do i = 1, dataNumberOfPoints
           if ( ( t >= x(ind, i) ) .and. ( t < x(ind, i+1) ) ) then
             indexBefore = i
-            indexAfter = i + 1
             linear_int_success = .true.
+            exit
           end if
         end do
         if ( linear_int_success .eqv. .false. ) then
           concAtT = y(ind, dataNumberOfPoints)
           write (*, '(A)') ' Failed to lin int'
         else
-          ! IDENTIFY COORDINATES OF ENCLOSING DATA POINTS
+          ! Identify coordinates of enclosing data points
           xBefore = x(ind, indexBefore)
           yBefore = y(ind, indexBefore)
-          xAfter = x(ind, indexAfter)
-          yAfter = y(ind, indexAfter)
-          ! DO LINEAR INTERPOLATION (Y = MX + C)
+          xAfter = x(ind, indexBefore + 1)
+          yAfter = y(ind, indexBefore + 1)
+          ! Do linear interpolation (Y = MX + C)
           m = ( yAfter - yBefore ) / ( xAfter - xBefore )
           c = yAfter - ( m * xAfter )
           concAtT = m * t + c

--- a/modelConfiguration/model.parameters
+++ b/modelConfiguration/model.parameters
@@ -1,8 +1,8 @@
 5		        number of steps
 900.0e+00		step size (seconds)
-4			      Species Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
-4			      Conditions Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
-4			      Dec Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
+2			      Species Interpolation Method (pw constant = 1, pw linear = 2)
+2			      Conditions Interpolation Method (pw constant = 1, pw linear = 2)
+2			      Dec Interpolation Method (pw constant = 1, pw linear = 2)
 10000		    Maximum Number of data points in constraint files
 3600			  rates output step size
 3600.00e+00	model start time

--- a/travis/tests/full/modelConfiguration/model.parameters
+++ b/travis/tests/full/modelConfiguration/model.parameters
@@ -1,8 +1,8 @@
 5		         number of steps
 900.0e+00		 step size (seconds)
-4			       Species Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
-4			       Conditions Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
-4			       Dec Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
+2			      Species Interpolation Method (pw constant = 1, pw linear = 2)
+2			      Conditions Interpolation Method (pw constant = 1, pw linear = 2)
+2			      Dec Interpolation Method (pw constant = 1, pw linear = 2)
 10000		     Maximum Number of data points in constraint files
 3600			   rates output step size
 3600.00e+00	 model start time

--- a/travis/tests/short/modelConfiguration/model.parameters
+++ b/travis/tests/short/modelConfiguration/model.parameters
@@ -1,8 +1,8 @@
 5		         number of steps
 900.0e+00		 step size (seconds)
-4			       Species Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
-4			       Conditions Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
-4			       Dec Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
+2			      Species Interpolation Method (pw constant = 1, pw linear = 2)
+2			      Conditions Interpolation Method (pw constant = 1, pw linear = 2)
+2			      Dec Interpolation Method (pw constant = 1, pw linear = 2)
 10000		     Maximum Number of data points in constraint files
 3600			   rates output step size
 3600.00e+00	 model start time

--- a/travis/tests/short_extended/modelConfiguration/model.parameters
+++ b/travis/tests/short_extended/modelConfiguration/model.parameters
@@ -1,8 +1,8 @@
 3		        number of steps
 1000.0e+00	step size (seconds)
-4			      Species Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
-4			      Conditions Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
-4			      Dec Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
+2			      Species Interpolation Method (pw constant = 1, pw linear = 2)
+2			      Conditions Interpolation Method (pw constant = 1, pw linear = 2)
+2			      Dec Interpolation Method (pw constant = 1, pw linear = 2)
 10000	    	Maximum Number of data points in constraint files
 3000			  rates output step size
 3600.00e+00	model start time

--- a/travis/tests/single_reac_of_interest/modelConfiguration/model.parameters
+++ b/travis/tests/single_reac_of_interest/modelConfiguration/model.parameters
@@ -1,8 +1,8 @@
 3		        number of steps
 1000.0e+00	step size (seconds)
-4			      Species Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
-4			      Conditions Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
-4			      Dec Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
+2			      Species Interpolation Method (pw constant = 1, pw linear = 2)
+2			      Conditions Interpolation Method (pw constant = 1, pw linear = 2)
+2			      Dec Interpolation Method (pw constant = 1, pw linear = 2)
 10000		    Maximum Number of data points in constraint files
 3000			  rates output step size
 3600.00e+00	model start time

--- a/travis/tests/spec_no_env_yes1/modelConfiguration/model.parameters
+++ b/travis/tests/spec_no_env_yes1/modelConfiguration/model.parameters
@@ -1,8 +1,8 @@
 4			  number of steps
 900			step size (seconds)
-4			  Species Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
-4			  Conditions Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
-4			  Dec Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
+2			      Species Interpolation Method (pw constant = 1, pw linear = 2)
+2			      Conditions Interpolation Method (pw constant = 1, pw linear = 2)
+2			      Dec Interpolation Method (pw constant = 1, pw linear = 2)
 50000		Maximum Number of data points in constraint files
 3600		rates output step size
 0			  model start time

--- a/travis/tests/spec_yes_env_no/modelConfiguration/model.parameters
+++ b/travis/tests/spec_yes_env_no/modelConfiguration/model.parameters
@@ -1,8 +1,8 @@
 4			number of steps
 900			step size (seconds)
-4			Species Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
-4			Conditions Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
-4			Dec Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
+2			      Species Interpolation Method (pw constant = 1, pw linear = 2)
+2			      Conditions Interpolation Method (pw constant = 1, pw linear = 2)
+2			      Dec Interpolation Method (pw constant = 1, pw linear = 2)
 50000			Maximum Number of data points in constraint files
 3600			rates output step size
 0			model start time

--- a/travis/tests/spec_yes_env_yes.out.cmp
+++ b/travis/tests/spec_yes_env_yes.out.cmp
@@ -152,67 +152,128 @@
  time = 900
  time = 1800
  time = 2700
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
- Failed to lin int
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.621E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.603E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.603E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.603E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.603E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.603E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.607E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.607E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.607E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.607E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.607E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.602E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.602E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.602E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.602E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.602E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.608E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.608E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.608E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.608E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.608E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.603E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.603E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.603E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.603E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.603E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.600E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.600E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.600E+03 15      6.800E+12
+ error in piecewise linear interpolation
+      3.600E+03 15      6.800E+12
  time = 3600
 
 

--- a/travis/tests/spec_yes_env_yes/modelConfiguration/model.parameters
+++ b/travis/tests/spec_yes_env_yes/modelConfiguration/model.parameters
@@ -1,8 +1,8 @@
 4			  number of steps
 900			step size (seconds)
-4			  Species Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
-4			  Conditions Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
-4			  Dec Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
+2			      Species Interpolation Method (pw constant = 1, pw linear = 2)
+2			      Conditions Interpolation Method (pw constant = 1, pw linear = 2)
+2			      Dec Interpolation Method (pw constant = 1, pw linear = 2)
 50000		Maximum Number of data points in constraint files
 3600		rates output step size
 0			  model start time

--- a/travis/tests/spec_yes_plus_fixed_env_no/modelConfiguration/model.parameters
+++ b/travis/tests/spec_yes_plus_fixed_env_no/modelConfiguration/model.parameters
@@ -1,8 +1,8 @@
 4			  number of steps
 900			step size (seconds)
-4			  Species Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
-4			  Conditions Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
-4			  Dec Interpolation Method (cs = 1, cs ln = 2, pw constant = 3, pw linear = 4)
+2			      Species Interpolation Method (pw constant = 1, pw linear = 2)
+2			      Conditions Interpolation Method (pw constant = 1, pw linear = 2)
+2			      Dec Interpolation Method (pw constant = 1, pw linear = 2)
 50000		Maximum Number of data points in constraint files
 3600		rates output step size
 0			  model start time


### PR DESCRIPTION
Remove cubic spline interpolants (methods 1 and 2) as they've never worked. Renumber 3 (left-handed p.w. constant interpolation) and 4 (p.w. linear interpolant) to 1 and 2 respectively. Fix all test input files.