### PR TITLE
Remove Y2 references

### DIFF
--- a/atchem.f90
+++ b/atchem.f90
@@ -516,7 +516,7 @@ PROGRAM ATCHEM
   ! deallocate arrays from module constraints_mod
   call deallocateConstrainedConcs()
   call deallocateConstrainedSpecies()
-  deallocate (dataX, dataY, dataY2, dataFixedY)
+  deallocate (dataX, dataY, dataFixedY)
   deallocate (speciesNumberOfPoints)
 
   ! deallocate arrays from module species_mod
@@ -524,10 +524,10 @@ PROGRAM ATCHEM
 
   ! deallocate arrays from module env_vars_mod
   deallocate (envVarTypesNum, envVarNames, envVarTypes, envVarFixedValues)
-  deallocate (envVarX, envVarY, envVarY2, envVarNumberOfPoints)
+  deallocate (envVarX, envVarY, envVarNumberOfPoints)
 
   ! deallocate arrays from module photolysis_rates_mod
-  deallocate (photoX, photoY, photoY2, photoNumberOfPoints)
+  deallocate (photoX, photoY, photoNumberOfPoints)
 
   ! Close output files and end program
   close (50)
@@ -626,7 +626,7 @@ subroutine FCVFUN( t, y, ydot, ipar, rpar, ier )
   do i = 1, numConSpec
     ! if it's a variable-concentration constrained species,
     if ( i <= numberOfVariableConstrainedSpecies ) then
-      call getConstrainedQuantAtT( t, datax, datay, datay2, speciesNumberOfPoints(i), &
+      call getConstrainedQuantAtT( t, datax, datay, speciesNumberOfPoints(i), &
                                    getSpeciesInterpMethod(), i, constrainedConcs(i) )
     else
       constrainedConcs(i) = dataFixedY(i - numberOfVariableConstrainedSpecies)

--- a/constraintFunctions.f90
+++ b/constraintFunctions.f90
@@ -43,7 +43,7 @@ contains
 
     ! GET CURRENT VALUE OF basePhotoRate
 
-    call getConstrainedQuantAtT( t, photoX, photoY, photoY2, photoNumberOfPoints (basePhotoRateNum), &
+    call getConstrainedQuantAtT( t, photoX, photoY, photoNumberOfPoints (basePhotoRateNum), &
                                  getConditionsInterpMethod(), basePhotoRateNum, JSpeciesAtT )
 
     if ( JSpeciesAtT == 0 ) then
@@ -227,7 +227,7 @@ contains
           end select
 
         case ( 2 ) ! CONSTRAINED
-          call getConstrainedQuantAtT( t, envVarX, envVarY, envVarY2, envVarNumberOfPoints(envVarNum), &
+          call getConstrainedQuantAtT( t, envVarX, envVarY, envVarNumberOfPoints(envVarNum), &
                                        getConditionsInterpMethod(), envVarNum, this_env_val )
 
           if (this_env_var_name == 'PRESS') pressure_set = .true.

--- a/dataStructures.f90
+++ b/dataStructures.f90
@@ -120,7 +120,7 @@ module env_vars_mod
   integer(kind=SI), allocatable :: envVarTypesNum(:)
   real(kind=DP), allocatable :: envVarFixedValues(:), currentEnvVarValues(:)
   integer(kind=SI) :: numEnvVars
-  real(kind=DP), allocatable :: envVarX (:,:), envVarY (:,:), envVarY2 (:,:)
+  real(kind=DP), allocatable :: envVarX (:,:), envVarY (:,:)
   integer(kind=NPI), allocatable :: envVarNumberOfPoints(:)
   real(kind=DP) :: ro2
 
@@ -144,7 +144,7 @@ module constraints_mod
   integer(kind=NPI) :: numberOfConstrainedSpecies
   integer(kind=NPI) :: numberOfFixedConstrainedSpecies, numberOfVariableConstrainedSpecies
   real(kind=DP), allocatable :: constrainedConcs(:)
-  real(kind=DP), allocatable :: dataX(:,:), dataY(:,:), dataY2(:,:), dataFixedY(:)
+  real(kind=DP), allocatable :: dataX(:,:), dataY(:,:), dataFixedY(:)
   integer(kind=NPI), allocatable :: constrainedSpecies(:)
   integer(kind=NPI) :: maxNumberOfDataPoints
   integer(kind=NPI), allocatable :: speciesNumberOfPoints(:)
@@ -420,7 +420,7 @@ module photolysis_rates_mod
   real(kind=DP), allocatable :: j(:)
   character(len=maxPhotoRateNameLength), allocatable :: photoRateNames(:)
   character(len=maxPhotoRateNameLength) :: constrainedPhotoRates(maxNrOfConPhotoRates), jFacSpecies
-  real(kind=DP), allocatable :: photoX(:,:), photoY(:,:), photoY2(:,:)
+  real(kind=DP), allocatable :: photoX(:,:), photoY(:,:)
   integer(kind=NPI), allocatable :: photoNumberOfPoints(:)
   integer(kind=NPI) :: size_of_j
 

--- a/inputFunctions.f90
+++ b/inputFunctions.f90
@@ -589,7 +589,6 @@ contains
     ! Allocate variables for next section
     allocate (envVarX(numEnvVars, maxNumberOfDataPoints))
     allocate (envVarY(numEnvVars, maxNumberOfDataPoints))
-    allocate (envVarY2(numEnvVars, maxNumberOfDataPoints))
     allocate (envVarNumberOfPoints(numEnvVars))
 
     ! TODO: convert this to a command line input argument
@@ -723,7 +722,6 @@ contains
     ! Allocate array size for storage of photolysis constraint data
     allocate (photoX (numConPhotoRates, maxNumberOfDataPoints) )
     allocate (photoY (numConPhotoRates, maxNumberOfDataPoints) )
-    allocate (photoY2 (numConPhotoRates, maxNumberOfDataPoints) )
     allocate (photoNumberOfPoints(numConPhotoRates) )
 
     fileLocationPrefix = trim( env_constraints_dir ) // "/"
@@ -743,7 +741,7 @@ contains
         end if
         open (11, file=fileLocation, status='old')
         do k = 1, photoNumberOfPoints(i)
-          read (11,*) photoX(i, k), photoY(i, k) !, photoY2 (i, k)
+          read (11,*) photoX(i, k), photoY(i, k)
         end do
         close (11, status='keep')
       end do
@@ -761,7 +759,7 @@ contains
     use species_mod
     use constraints_mod, only : maxNumberOfDataPoints, speciesNumberOfPoints, numberOfVariableConstrainedSpecies, &
                                 numberOfFixedConstrainedSpecies, setNumberOfConstrainedSpecies, setConstrainedConcs, &
-                                setConstrainedSpecies, getOneConstrainedSpecies, dataX, dataY, dataY2, dataFixedY
+                                setConstrainedSpecies, getOneConstrainedSpecies, dataX, dataY, dataFixedY
     use directories_mod, only : param_dir, spec_constraints_dir
     use storage_mod, only : maxSpecLength, maxFilepathLength
     use configFunctions_mod, only : getIndexWithinList
@@ -820,7 +818,6 @@ contains
     write (*, '(A)') ' Allocating storage for variable-concentration constrained species...'
     allocate (dataX(numberOfVariableConstrainedSpecies, maxNumberOfDataPoints) )
     allocate (dataY(numberOfVariableConstrainedSpecies, maxNumberOfDataPoints) )
-    allocate (dataY2(numberOfVariableConstrainedSpecies, maxNumberOfDataPoints) )
     write (*, '(A)') ' Finished allocating storage for variable-concentration constrained species.'
 
     if ( numberOfVariableConstrainedSpecies > 0 ) then
@@ -858,7 +855,7 @@ contains
         call inquire_or_abort( fileLocation, 'readSpeciesConstraints()')
         open (13, file=fileLocation, status='old')
         do k = 1, dataNumberOfPoints
-          read (13,*) dataX(i, k), dataY(i, k) !, dataY2(i, k)
+          read (13,*) dataX(i, k), dataY(i, k)
         end do
         close (13, status='keep')
       end do
@@ -918,7 +915,7 @@ contains
     allocate (concAtT(numberOfConstrainedSpecies))
     do i = 1, numberOfConstrainedSpecies
       if ( i <= numberOfVariableConstrainedSpecies ) then
-        call getConstrainedQuantAtT( t, datax, datay, datay2, speciesNumberOfPoints(i), getSpeciesInterpMethod(), i, concAtT(i) )
+        call getConstrainedQuantAtT( t, datax, datay, speciesNumberOfPoints(i), getSpeciesInterpMethod(), i, concAtT(i) )
       else
         concAtT(i) = dataFixedY(i - numberOfVariableConstrainedSpecies)
       end if

--- a/interpolationFunctions.f90
+++ b/interpolationFunctions.f90
@@ -8,15 +8,15 @@ contains
 
   ! -----------------------------------------------------------------
   ! This routine returns in concAtT the value of the requested
-  ! quantity (referenced by the ind-th line of x, y, y2) based upon
+  ! quantity (referenced by the ind-th line of x, y) based upon
   ! the constraint data given and interpolation method given
-  subroutine getConstrainedQuantAtT( t, x, y, y2, dataNumberOfPoints, interpMethod, ind, concAtT )
+  subroutine getConstrainedQuantAtT( t, x, y, dataNumberOfPoints, interpMethod, ind, concAtT )
     use, intrinsic :: iso_fortran_env, only : stderr => error_unit
     use types_mod
     use interpolation_method_mod
     implicit none
 
-    real(kind=DP), intent(in) :: t, x(:,:), y(:,:), y2(:,:)
+    real(kind=DP), intent(in) :: t, x(:,:), y(:,:)
     integer(kind=NPI), intent(in) :: dataNumberOfPoints
     integer(kind=SI), intent(in) :: interpMethod
     integer(kind=NPI), intent(in) :: ind
@@ -25,18 +25,12 @@ contains
     integer(kind=NPI) :: i, indexBefore
     logical :: interp_success
 
-    ! Sanity checks on sizes of x, y and y2.
+    ! Sanity checks on sizes of x and y.
     if ( size( x, 1 ) /= size( y, 1 ) ) then
       stop 'size( x, 1 ) /= size( y, 1 ) in getConstrainedQuantAtT()'
     end if
-    if ( size( x, 1 ) /= size( y2, 1 ) ) then
-      stop 'size( x, 1 ) /= size( y2, 1 ) in getConstrainedQuantAtT()'
-    end if
     if ( size( x, 2 ) /= size( y, 2 ) ) then
       stop 'size( x, 2 ) /= size( y, 2 ) in getConstrainedQuantAtT()'
-    end if
-    if ( size( x, 2 ) /= size( y2, 2 ) ) then
-      stop 'size( x, 2 ) /= size( y2, 2 ) in getConstrainedQuantAtT()'
     end if
 
     ! Find the interval in which t sits

--- a/solverFunctions.f90
+++ b/solverFunctions.f90
@@ -207,7 +207,7 @@ contains
     end do
 
     do i = 1, numConPhotoRates
-      call getConstrainedQuantAtT( t, photoX, photoY, photoY2, photoNumberOfPoints(i), &
+      call getConstrainedQuantAtT( t, photoX, photoY, photoNumberOfPoints(i), &
                                    getConditionsInterpMethod(), i, photoRateAtT )
       j(constrainedPhotoRatesNumbers(i)) = photoRateAtT
     end do


### PR DESCRIPTION
Remove all references to y2, dataY2, photoY2 or envVarY2, and remove this as an argument from getConstrainedQuantAtT().