### PR TITLE
Standardise parameter input file reads

### DIFF
--- a/inputFunctions.f90
+++ b/inputFunctions.f90
@@ -493,29 +493,21 @@ contains
 
   ! -----------------------------------------------------------------
   ! Read in parameters from file at input_file, and save the contents
-  ! of each line to an element of the array
+  ! of each line to an element of parameterArray
   function getParametersFromFile( input_file ) result ( parameterArray )
     use types_mod
     implicit none
 
     character(len=*), intent(in) :: input_file
     real(kind=DP), allocatable :: parameterArray(:)
-    character(len=100) :: dummy
-    integer(kind=DI) :: numValidEntries, counter
+    integer(kind=NPI) :: num_lines, counter
 
     call inquire_or_abort( input_file, 'getParametersFromFile()')
+    num_lines = count_lines_in_file( input_file, skip_first_line_in=.false. )
+    allocate (parameterArray(num_lines))
 
     open (10, file=input_file, status='old') ! input file
-    numValidEntries = 0
-    read (10,*) dummy
-    do while ( dummy /= '-9999' )
-      numValidEntries = numValidEntries + 1_DI
-      read (10,*) dummy
-    end do
-    close (10, status='keep')
-    allocate (parameterArray(numValidEntries))
-    open (10, file=input_file, status='old') ! input file
-    do counter = 1, numValidEntries
+    do counter = 1_NPI, num_lines
       read (10,*) parameterArray(counter)
     end do
     close (10, status='keep')

--- a/modelConfiguration/model.parameters
+++ b/modelConfiguration/model.parameters
@@ -13,4 +13,3 @@
 06			month
 2010			year
 1800			instantaneous rates output step size
--9999			end of file

--- a/modelConfiguration/solver.parameters
+++ b/modelConfiguration/solver.parameters
@@ -7,19 +7,3 @@
 2			Solver Type (1 = SPGMR, 2 = SPGMR + Banded Preconditioner, 3 = Dense)
 750			Banded Preconditioner Upper Bandwidth
 750			Banded Preconditioner Lower Bandwidth
--9999			End of File
-
-For one day
-96.0e+00		number of steps
-900.0e+00		step size
-
-for two days
-192.0e+00		number of steps
-900.0e+00		step size
-
-2880.0e+00		number of steps
-60.0e+00		step size
-
-standard
-1.0e-04		atol
-1.0e-06		rtol

--- a/travis/tests/full/modelConfiguration/model.parameters
+++ b/travis/tests/full/modelConfiguration/model.parameters
@@ -13,4 +13,3 @@
 11			     month
 2008			   year
 900			     Instantaneous Rates Output Step Size
--9999	       End of File

--- a/travis/tests/full/modelConfiguration/solver.parameters
+++ b/travis/tests/full/modelConfiguration/solver.parameters
@@ -7,19 +7,3 @@
 2				    Solver Type (1 = SPGMR, 2 = SPGMR + Banded Preconditioner, 3 = Dense)
 750				  Banded Preconditioner Upper Bandwidth
 750				  Banded Preconditioner Lower Bandwidth
--9999 	    End of File
-
-For one day
-96.0e+00		number of steps
-900.0e+00		step size
-
-for two days
-192.0e+00		number of steps
-900.0e+00		step size
-
-2880.0e+00	number of steps
-60.0e+00		step size
-
-standard
-1.0e-04		  atol
-1.0e-06	 	  rtol

--- a/travis/tests/short/modelConfiguration/model.parameters
+++ b/travis/tests/short/modelConfiguration/model.parameters
@@ -13,4 +13,3 @@
 11		month
 2008		year
 300		Instantaneous Rates Output Step Size
--9999		End of File

--- a/travis/tests/short/modelConfiguration/solver.parameters
+++ b/travis/tests/short/modelConfiguration/solver.parameters
@@ -7,19 +7,3 @@
 2			Solver Type (1 = SPGMR, 2 = SPGMR + Banded Preconditioner, 3 = Dense)
 750			Banded Preconditioner Upper Bandwidth
 750			Banded Preconditioner Lower Bandwidth
--9999			End of File
-
-For one day
-96.0e+00		number of steps
-900.0e+00		step size
-
-for two days
-192.0e+00		number of steps
-900.0e+00		step size
-
-2880.0e+00		number of steps
-60.0e+00		step size
-
-standard
-1.0e-04		atol
-1.0e-06		rtol

--- a/travis/tests/short_ext1/modelConfiguration/model.parameters
+++ b/travis/tests/short_ext1/modelConfiguration/model.parameters
@@ -13,4 +13,3 @@
 08		month
 2010		year
 300		Instantaneous Rates Output Step Size
--9999		End of File

--- a/travis/tests/short_ext1/modelConfiguration/solver.parameters
+++ b/travis/tests/short_ext1/modelConfiguration/solver.parameters
@@ -7,19 +7,3 @@
 2			Solver Type (1 = SPGMR, 2 = SPGMR + Banded Preconditioner, 3 = Dense)
 750			Banded Preconditioner Upper Bandwidth
 750			Banded Preconditioner Lower Bandwidth
--9999			End of File
-
-For one day
-96.0e+00		number of steps
-900.0e+00		step size
-
-for two days
-192.0e+00		number of steps
-900.0e+00		step size
-
-2880.0e+00		number of steps
-60.0e+00		step size
-
-standard
-1.0e-04		atol
-1.0e-06		rtol

--- a/travis/tests/short_ext2/modelConfiguration/model.parameters
+++ b/travis/tests/short_ext2/modelConfiguration/model.parameters
@@ -13,4 +13,3 @@
 08		month
 2010		year
 300		Instantaneous Rates Output Step Size
--9999		End of File

--- a/travis/tests/short_ext2/modelConfiguration/solver.parameters
+++ b/travis/tests/short_ext2/modelConfiguration/solver.parameters
@@ -7,19 +7,3 @@
 2			Solver Type (1 = SPGMR, 2 = SPGMR + Banded Preconditioner, 3 = Dense)
 750			Banded Preconditioner Upper Bandwidth
 750			Banded Preconditioner Lower Bandwidth
--9999			End of File
-
-For one day
-96.0e+00		number of steps
-900.0e+00		step size
-
-for two days
-192.0e+00		number of steps
-900.0e+00		step size
-
-2880.0e+00		number of steps
-60.0e+00		step size
-
-standard
-1.0e-04		atol
-1.0e-06		rtol

--- a/travis/tests/short_ext3/modelConfiguration/model.parameters
+++ b/travis/tests/short_ext3/modelConfiguration/model.parameters
@@ -13,4 +13,3 @@
 02		month
 2010		year
 300		Instantaneous Rates Output Step Size
--9999		End of File

--- a/travis/tests/short_ext3/modelConfiguration/solver.parameters
+++ b/travis/tests/short_ext3/modelConfiguration/solver.parameters
@@ -7,19 +7,3 @@
 2			Solver Type (1 = SPGMR, 2 = SPGMR + Banded Preconditioner, 3 = Dense)
 750			Banded Preconditioner Upper Bandwidth
 750			Banded Preconditioner Lower Bandwidth
--9999			End of File
-
-For one day
-96.0e+00		number of steps
-900.0e+00		step size
-
-for two days
-192.0e+00		number of steps
-900.0e+00		step size
-
-2880.0e+00		number of steps
-60.0e+00		step size
-
-standard
-1.0e-04		atol
-1.0e-06		rtol

--- a/travis/tests/short_ext4/modelConfiguration/model.parameters
+++ b/travis/tests/short_ext4/modelConfiguration/model.parameters
@@ -13,4 +13,3 @@
 02		month
 2010		year
 300		Instantaneous Rates Output Step Size
--9999		End of File

--- a/travis/tests/short_ext4/modelConfiguration/solver.parameters
+++ b/travis/tests/short_ext4/modelConfiguration/solver.parameters
@@ -7,19 +7,3 @@
 2			Solver Type (1 = SPGMR, 2 = SPGMR + Banded Preconditioner, 3 = Dense)
 750			Banded Preconditioner Upper Bandwidth
 750			Banded Preconditioner Lower Bandwidth
--9999			End of File
-
-For one day
-96.0e+00		number of steps
-900.0e+00		step size
-
-for two days
-192.0e+00		number of steps
-900.0e+00		step size
-
-2880.0e+00		number of steps
-60.0e+00		step size
-
-standard
-1.0e-04		atol
-1.0e-06		rtol

--- a/travis/tests/spec_no_env_yes1/modelConfiguration/model.parameters
+++ b/travis/tests/spec_no_env_yes1/modelConfiguration/model.parameters
@@ -13,4 +13,3 @@
 07			month
 2007		year
 3600		Instantaneous Rates Output Step Size
--9999	 	End of File

--- a/travis/tests/spec_no_env_yes1/modelConfiguration/solver.parameters
+++ b/travis/tests/spec_no_env_yes1/modelConfiguration/solver.parameters
@@ -7,19 +7,3 @@
 2			  Solver Type (1 = SPGMR, 2 = SPGMR + Banded Preconditioner, 3 = Dense)
 750			Banded Preconditioner Upper Bandwidth
 750			Banded Preconditioner Lower Bandwidth
--9999	 	End of File
-
-For one day
-96.0e+00		number of steps
-900.0e+00		step size
-
-for two days
-192.0e+00		number of steps
-900.0e+00		step size
-
-2880.0e+00	number of steps
-60.0e+00		step size
-
-standard
-1.0e-04		  atol
-1.0e-06	 	  rtol

--- a/travis/tests/spec_no_env_yes2/modelConfiguration/model.parameters
+++ b/travis/tests/spec_no_env_yes2/modelConfiguration/model.parameters
@@ -13,4 +13,3 @@
 07			month
 2007			year
 3600			Instantaneous Rates Output Step Size
--9999 End of File

--- a/travis/tests/spec_no_env_yes2/modelConfiguration/solver.parameters
+++ b/travis/tests/spec_no_env_yes2/modelConfiguration/solver.parameters
@@ -7,19 +7,3 @@
 2           Solver Type (1 = SPGMR, 2 = SPGMR + Banded Preconditioner, 3 = Dense)
 750         Banded Preconditioner Upper Bandwidth
 750         Banded Preconditioner Lower Bandwidth
--9999       End of File
-
-For one day
-96.0e+00    number of steps
-900.0e+00   step size
-
-for two days
-192.0e+00   number of steps
-900.0e+00   step size
-
-2880.0e+00  number of steps
-60.0e+00    step size
-
-standard
-1.0e-04     atol
-1.0e-06     rtol

--- a/travis/tests/spec_yes_env_no/modelConfiguration/model.parameters
+++ b/travis/tests/spec_yes_env_no/modelConfiguration/model.parameters
@@ -13,4 +13,3 @@
 07			month
 2007			year
 3600			Instantaneous Rates Output Step Size
--9999	-9999	-9999	-9999 	End of File

--- a/travis/tests/spec_yes_env_no/modelConfiguration/solver.parameters
+++ b/travis/tests/spec_yes_env_no/modelConfiguration/solver.parameters
@@ -7,19 +7,3 @@
 2			Solver Type (1 = SPGMR, 2 = SPGMR + Banded Preconditioner, 3 = Dense)
 750			Banded Preconditioner Upper Bandwidth
 750			Banded Preconditioner Lower Bandwidth
--9999	-9999	-9999	-9999 	End of File
-
-For one day
-96.0e+00		number of steps
-900.0e+00		step size
-
-for two days
-192.0e+00		number of steps
-900.0e+00		step size
-
-2880.0e+00		number of steps
-60.0e+00		step size
-
-standard
-1.0e-04		atol
-1.0e-06	 	rtol

--- a/travis/tests/spec_yes_env_no_with_jfac/modelConfiguration/model.parameters
+++ b/travis/tests/spec_yes_env_no_with_jfac/modelConfiguration/model.parameters
@@ -13,4 +13,3 @@
 07			month
 2007			year
 3600			Instantaneous Rates Output Step Size
--9999	-9999	-9999	-9999 	End of File

--- a/travis/tests/spec_yes_env_no_with_jfac/modelConfiguration/solver.parameters
+++ b/travis/tests/spec_yes_env_no_with_jfac/modelConfiguration/solver.parameters
@@ -7,19 +7,3 @@
 2			Solver Type (1 = SPGMR, 2 = SPGMR + Banded Preconditioner, 3 = Dense)
 750			Banded Preconditioner Upper Bandwidth
 750			Banded Preconditioner Lower Bandwidth
--9999	-9999	-9999	-9999 	End of File
-
-For one day
-96.0e+00		number of steps
-900.0e+00		step size
-
-for two days
-192.0e+00		number of steps
-900.0e+00		step size
-
-2880.0e+00		number of steps
-60.0e+00		step size
-
-standard
-1.0e-04		atol
-1.0e-06	 	rtol

--- a/travis/tests/spec_yes_env_no_with_photo/modelConfiguration/model.parameters
+++ b/travis/tests/spec_yes_env_no_with_photo/modelConfiguration/model.parameters
@@ -13,4 +13,3 @@
 07			month
 2007			year
 3600			Instantaneous Rates Output Step Size
--9999	-9999	-9999	-9999 	End of File

--- a/travis/tests/spec_yes_env_no_with_photo/modelConfiguration/solver.parameters
+++ b/travis/tests/spec_yes_env_no_with_photo/modelConfiguration/solver.parameters
@@ -7,19 +7,3 @@
 2			Solver Type (1 = SPGMR, 2 = SPGMR + Banded Preconditioner, 3 = Dense)
 750			Banded Preconditioner Upper Bandwidth
 750			Banded Preconditioner Lower Bandwidth
--9999	-9999	-9999	-9999 	End of File
-
-For one day
-96.0e+00		number of steps
-900.0e+00		step size
-
-for two days
-192.0e+00		number of steps
-900.0e+00		step size
-
-2880.0e+00		number of steps
-60.0e+00		step size
-
-standard
-1.0e-04		atol
-1.0e-06	 	rtol

--- a/travis/tests/spec_yes_env_yes/modelConfiguration/model.parameters
+++ b/travis/tests/spec_yes_env_yes/modelConfiguration/model.parameters
@@ -13,4 +13,3 @@
 07			month
 2007		year
 3600		Instantaneous Rates Output Step Size
--9999	 	End of File

--- a/travis/tests/spec_yes_env_yes/modelConfiguration/solver.parameters
+++ b/travis/tests/spec_yes_env_yes/modelConfiguration/solver.parameters
@@ -7,19 +7,3 @@
 2			      Solver Type (1 = SPGMR, 2 = SPGMR + Banded Preconditioner, 3 = Dense)
 750			    Banded Preconditioner Upper Bandwidth
 750			    Banded Preconditioner Lower Bandwidth
--9999       End of File
-
-For one day
-96.0e+00		number of steps
-900.0e+00		step size
-
-for two days
-192.0e+00		number of steps
-900.0e+00		step size
-
-2880.0e+00	number of steps
-60.0e+00		step size
-
-standard
-1.0e-04		  atol
-1.0e-06	 	  rtol

--- a/travis/tests/spec_yes_plus_fixed_env_no/modelConfiguration/model.parameters
+++ b/travis/tests/spec_yes_plus_fixed_env_no/modelConfiguration/model.parameters
@@ -13,4 +13,3 @@
 07			month
 2007		year
 3600		Instantaneous Rates Output Step Size
--9999   End of File

--- a/travis/tests/spec_yes_plus_fixed_env_no/modelConfiguration/solver.parameters
+++ b/travis/tests/spec_yes_plus_fixed_env_no/modelConfiguration/solver.parameters
@@ -7,19 +7,3 @@
 2			      Solver Type (1 = SPGMR, 2 = SPGMR + Banded Preconditioner, 3 = Dense)
 750			    Banded Preconditioner Upper Bandwidth
 750			    Banded Preconditioner Lower Bandwidth
--9999       End of File
-
-For one day
-96.0e+00		number of steps
-900.0e+00		step size
-
-for two days
-192.0e+00		number of steps
-900.0e+00		step size
-
-2880.0e+00	number of steps
-60.0e+00		step size
-
-standard
-1.0e-04		  atol
-1.0e-06	 	  rtol


### PR DESCRIPTION
Remove extraneous lines from all `solver.parameters` and `model.parameters files`, and count the lines rather than rely on a `-9999 End of file` line.